### PR TITLE
Making statsd play nicely with netcat

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -36,7 +36,7 @@ config.configFile(process.argv[2], function (config, oldConfig) {
       for (var i = 0; i < bits.length; i++) {
         var sampleRate = 1;
         var fields = bits[i].split("|");
-        if (fields[1] == "ms") {
+        if (fields[1].trim() == "ms") {
           if (! timers[key]) {
             timers[key] = [];
           }


### PR DESCRIPTION
Before, timing messages sent via netcat were tagged as counters instead of timers:
`$ echo 'glork:320|ms'|nc -u <server> 8125`

```
12 Feb 04:06:56 - Counters:
{ glork: 320 }
Timers:
{}
```

With this change, timing messages sent via netcat are treated accordingly:
`$ echo 'glork:320|ms'|nc -u <server> 8125`

```
12 Feb 04:33:36 - Counters:
{}
Timers:
{ glork: [ 320 ] }
```
