### PR TITLE
New command to stop sending counters/timers to Graphite

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -5,7 +5,7 @@ var dgram  = require('dgram')
 
 var counters = {};
 var timers = {};
-var debugInt, flushInt, server;
+var debugInt, flushInt, server, packetCount;
 
 config.configFile(process.argv[2], function (config, oldConfig) {
   if (! config.debug && debugInt) {
@@ -21,8 +21,10 @@ config.configFile(process.argv[2], function (config, oldConfig) {
   }
 
   if (server === undefined) {
+    packetCount = 0;
     server = dgram.createSocket('udp4', function (msg, rinfo) {
       if (config.dumpMessages) { sys.log(msg.toString()); }
+      packetCount += 1;
       var bits = msg.toString().split(':');
       var key = bits.shift()
                     .replace(/\s+/g, '_')
@@ -130,6 +132,8 @@ config.configFile(process.argv[2], function (config, oldConfig) {
       }
 
       statString += 'statsd.numStats ' + numStats + ' ' + ts + "\n";
+      statString += 'statsd.packetCount ' + packetCount + ' ' + ts + "\n";
+      packetCount = 0;
       
       try {
         var graphite = net.createConnection(config.graphitePort, config.graphiteHost);


### PR DESCRIPTION
Sometimes we kill old stats and no longer wish to have them being sent from StatsD as 0. Two new commands will tell StatsD to stop sending them (sets them to undefined in the counter/timers array).

Usage:
To stop sending the stat named "stat.name.here", send:
stat.name.here:0|stopc

To stop sending the timing stat named "stat.name.here", send:
stat.name.here:0|stopms
