### PR TITLE
Remove stats value

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -68,9 +68,7 @@ config.configFile(process.argv[2], function (config, oldConfig) {
       var key;
 
       for (key in counters) {
-        var value = counters[key] / (flushInterval / 1000);
-        var message = 'stats.' + key + ' ' + value + ' ' + ts + "\n";
-        message += 'stats_counts.' + key + ' ' + counters[key] + ' ' + ts + "\n";
+        var message = 'stats_counts.' + key + ' ' + counters[key] + ' ' + ts + "\n";
         statString += message;
         counters[key] = 0;
 


### PR DESCRIPTION
The stats value is an average that is computed and passed to graphite.
As graphite later takes averages of values over the retention periods,
this forms an average of an average, which corrupts the data.
