### PR TITLE
Add multiple buckets of metrics to be flushed at different intervals.

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -2,6 +2,8 @@
   graphitePort: 2003
 , graphiteHost: "graphite.host.com"
 , port: 8125
+, statusPort: 8126
+, statusAddr: "0.0.0.0"
 , flushBuckets: [
     {
       pattern: "^.*"

--- a/stats.js
+++ b/stats.js
@@ -2,10 +2,11 @@ var dgram  = require('dgram')
   , sys    = require('sys')
   , net    = require('net')
   , config = require('./config')
+  , http = require('http');
 
 var counters = [];
 var timers = [];
-var debugInt, flushInts = [], server, sserver;
+var debugInt, flushInts = [], server;
 
 
 String.prototype.startsWith = function(str) {
@@ -46,6 +47,26 @@ config.configFile(process.argv[2], function (config, oldConfig) {
     debugInt = setInterval(function () { 
       sys.log("Counters:\n" + sys.inspect(counters) + "\nTimers:\n" + sys.inspect(timers));
     }, config.debugInterval || 10000);
+  }
+                    
+  // status server
+  if (sserver === undefined) {
+    sserver = http.createServer(function (req, res) {
+      if (req.url.substring(0, 5) === "/ping") {
+        res.writeHead(200, {'Content-Type': 'text/plain'});
+        res.end('PONG\n');
+      }
+      else {
+        res.writeHead(200, {'Content-Type': 'application/json'});
+        var status = {
+          'timers': timers,
+          'counters': counters
+        };
+        res.end(sys.inspect(status));
+      }
+    });
+
+    sserver.listen(config.statusPort, config.statusAddr || "127.0.0.1");
   }
 
   if (server === undefined) {


### PR DESCRIPTION
I feel as though we're replicating whisper here, but that's OK. 

These commits add a notion of "flush buckets" which allow you to group stats such that they can be flushed at different intervals. The config should be backwards compatible as if the flush buckets config entry is not present, we default to one that defines the config that'd be necessary for the current statsd to function.

Let me know if you have other questions or concerns.
