### PR TITLE
Add multiple buckets of metrics to be flushed at different intervals.

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -2,6 +2,8 @@
   graphitePort: 2003
 , graphiteHost: "graphite.host.com"
 , port: 8125
+, statusPort: 8126
+, statusAddr: "0.0.0.0"
 , flushBuckets: [
     {
       pattern: "^.*"


### PR DESCRIPTION
This commit adds multiple buckets for collecting metrics which can be dumped at different intervals and with different prefixes (than just stats.). There is a lot of changes, but should remain backwards compatible with the exampleConfig currently provided. We're running this in production now, but I'm willing to make changes to accommodate the greater good.
