### PR TITLE
Remove use of deprecated process.compile to work with node 0.6x

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,7 +14,7 @@ var Configurator = function (file) {
       if (err) { throw err; }
       old_config = self.config;
 
-      self.config = process.compile('config = ' + data, file);
+      self.config = eval('config = ' + fs.readFileSync(file));
       self.emit('configChanged', self.config);
     });
   };


### PR DESCRIPTION
Not sure exactly when process.compile was deprecated, but fs.readFileSync() has been around for a long time so this is backwards compatible. Without this fix the following error is thrown:

```
10 Nov 04:07:46 - reading config file: configuration.js

/opt/statsd/config.js:17
      self.config = process.compile('config = ' + data, file);
                            ^
TypeError: Object #<EventEmitter> has no method 'compile'
    at /opt/statsd/config.js:17:29
    at [object Object].<anonymous> (fs.js:114:5)
    at [object Object].emit (events.js:64:17)
    at afterRead (fs.js:1080:12)
    at Object.wrapper [as oncomplete] (fs.js:252:17)
```
