### PR TITLE
Make Graphite connection config variables optional to allow 'dry' server mode.

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -2,9 +2,16 @@
 
 Required Variables:
 
+  port:             StatsD listening port [default: 8125]
+
+Graphite Required Variables:
+
+(Leave these unset to avoid sending stats to Graphite.
+ Set debug flag and leave these unset to run in 'dry' debug mode -
+ useful for testing statsd clients without a Graphite server.)
+
   graphiteHost:     hostname or IP of Graphite server
   graphitePort:     port of Graphite server
-  port:             StatsD listening port [default: 8125]
 
 Optional Variables:
 

--- a/stats.js
+++ b/stats.js
@@ -191,23 +191,25 @@ config.configFile(process.argv[2], function (config, oldConfig) {
 
       statString += 'statsd.numStats ' + numStats + ' ' + ts + "\n";
       
-      try {
-        var graphite = net.createConnection(config.graphitePort, config.graphiteHost);
-        graphite.addListener('error', function(connectionException){
+      if (config.graphiteHost) {
+        try {
+          var graphite = net.createConnection(config.graphitePort, config.graphiteHost);
+          graphite.addListener('error', function(connectionException){
+            if (config.debug) {
+              sys.log(connectionException);
+            }
+          });
+          graphite.on('connect', function() {
+            this.write(statString);
+            this.end();
+            stats['graphite']['last_flush'] = Math.round(new Date().getTime() / 1000);
+          });
+        } catch(e){
           if (config.debug) {
-            sys.log(connectionException);
+            sys.log(e);
           }
-        });
-        graphite.on('connect', function() {
-          this.write(statString);
-          this.end();
-          stats['graphite']['last_flush'] = Math.round(new Date().getTime() / 1000);
-        });
-      } catch(e){
-        if (config.debug) {
-          sys.log(e);
+          stats['graphite']['last_exception'] = Math.round(new Date().getTime() / 1000);
         }
-        stats['graphite']['last_exception'] = Math.round(new Date().getTime() / 1000);
       }
 
     }, flushInterval);


### PR DESCRIPTION
Make Graphite connection config variables optional.  Leaving them out avoids connecting to Graphite at all.  Use in combination with debug mode to develop and test statsd clients without a Graphite server.
