### PR TITLE
Fixed Rails Example

### DIFF
--- a/examples/ruby_example2.rb
+++ b/examples/ruby_example2.rb
@@ -74,11 +74,10 @@ class Statsd
     end
   end
 
-  @@config = {}
   def self.config
-    return @@config if @@config
+    return @@config if self.class_variable_defined?(:@@config)
     begin 
-      config_path = File.join(File.dir(__FILE__), "statsd.yml")
+      config_path = File.join(File.dirname(__FILE__), "statsd.yml")
       # for Rails environments, check Rails.root/config/statsd.yml
       if defined? Rails
         config_path = File.join(Rails.root, "config", "statsd.yml")


### PR DESCRIPTION
I am using statsd hosted on an amazon instance.  Everything worked when I copied your Rails example and tested locally, but it wouldn't work in the cloud.

Debugging showed me it was that the config was always blank and therefore defaulted to "localhost:8125".  I have fixed it to properly load config in both the rails and normal case.
