### PR TITLE
Add gauge types.

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -241,7 +241,7 @@ config.configFile(process.argv[2], function (config, oldConfig) {
       }
 
       for (key in gauges) {
-        statString += 'stats.' + key + ' ' + gauges[key] + ' ' + ts + "\n";
+        statString += 'stats.gauges.' + key + ' ' + gauges[key] + ' ' + ts + "\n";
         numStats += 1;
       }
 


### PR DESCRIPTION
Some applications have absolute values that they'd like to track as a simple
gauge, rather than as a count per period. This change adds support for this
type. Clients can set a gauge by sending 'value|g'.

Any gauge value which is set will persist and be flushed out to graphite each
iteration. This means that the gauge can be set once, and that value will be
graphed continuously until the next time it's set.
