### PR TITLE
Debian package scripts don't install the graphite backend file

### DIFF
--- a/debian/statsd.install
+++ b/debian/statsd.install
@@ -1,4 +1,5 @@
 stats.js	/usr/share/statsd
 config.js	/usr/share/statsd
+backends/graphite.js  /usr/share/statsd/backends
 debian/localConfig.js	/etc/statsd
 debian/scripts/start	/usr/share/statsd/scripts


### PR DESCRIPTION
On April 26th, a change was made to split the logic for talking to graphite out to a separate file, however that file isn't in the statsd.install file so building a deb package will skip over it.

This simple adds the file so debhelper will package it.
