### PR TITLE
Adding a statsd backend for ElasticSearch

### DIFF
--- a/backends/elastic.js
+++ b/backends/elastic.js
@@ -1,0 +1,166 @@
+/*
+ * Flush stats to ElasticSearch (http://www.elasticsearch.org/)
+ *
+ * To enable this backend, include 'elastic' in the backends
+ * configuration array:
+ *
+ *   backends: ['./backends/elastic'] 
+ *  (if the config file is in the statsd folder)
+ *
+ * A sample configuration can be found in exampleElasticConfig.js
+ *
+ * This backend supports the following config options:
+ *
+ *   elasticHost:          hostname or IP of ElasticSearch server
+ *   elasticPort:          port of Elastic Search Server
+ *   elasticIndex:         Index of the ElasticSearch server where the metrics are to be saved (_index)
+ *   elasticIndexType:     The type of the index to be saved with (_type)
+ *   elasticFlushInterval: Right now, not being used and is the same as flushInterval, but hope to use this to make the logging to ES over a longer interval than for graphite
+ */
+
+var net = require('net'),
+   util = require('util'),
+   http = require('http');
+
+var debug;
+var flushInterval;
+var elasticHost;
+var elasticPort;
+var elasticIndex;
+var elasticIndexType;
+
+var elasticStats = {};
+
+var post_stats = function elastic_post_stats(statString) {
+  if (elasticHost) {
+    try {
+      var elastic = require('../utils/httpReq')
+	  elasticUrl = 'http://' + elasticHost + ':' + elasticPort + '/' + elasticIndex + '/' + elasticIndexType ; 
+	  elastic.urlReq(elasticUrl,{
+      method: 'POST',
+      params: statString.toString() 
+	}, function(body, res){
+
+      });
+	  
+
+    } catch(e){
+      if (debug) {
+        util.log(e);
+      }
+      elasticStats.last_exception = Math.round(new Date().getTime() / 1000);
+    }
+  }
+}
+
+var flush_stats = function elastic_flush(ts, metrics) {
+  var statString = '';
+  var numStats = 0;
+  var key;
+  var message_array = new Array();
+
+  ts = new Date()
+  var counters = metrics.counters;
+  var gauges = metrics.gauges;
+  var timers = metrics.timers;
+  var pctThreshold = metrics.pctThreshold;
+
+  for (key in counters) {
+    var value = counters[key];
+    var valuePerSecond = value / (flushInterval / 1000); // calculate "per second" rate
+
+    //statString += 'stats.'        + key + ' ' + valuePerSecond + ' ' +  "\n";
+    //statString += 'stats_counts.' + key + ' ' + value          + ' ' +  "\n";
+    message_array.push(create_json(key + '.persecond',valuePerSecond,ts));
+    message_array.push(create_json(key,value,ts));
+
+    numStats += 1;
+  }
+
+  for (key in timers) {
+    if (timers[key].length > 0) {
+      var values = timers[key].sort(function (a,b) { return a-b; });
+      var count = values.length;
+      var min = values[0];
+      var max = values[count - 1];
+
+      var mean = min;
+      var maxAtThreshold = max;
+
+      var message = "";
+
+      var key2;
+
+      for (key2 in pctThreshold) {
+        var pct = pctThreshold[key2];
+        if (count > 1) {
+          var thresholdIndex = Math.round(((100 - pct) / 100) * count);
+          var numInThreshold = count - thresholdIndex;
+          var pctValues = values.slice(0, numInThreshold);
+          maxAtThreshold = pctValues[numInThreshold - 1];
+
+          // average the remaining timings
+          var sum = 0;
+          for (var i = 0; i < numInThreshold; i++) {
+            sum += pctValues[i];
+          }
+
+          mean = sum / numInThreshold;
+        }
+
+        var clean_pct = '' + pct;
+        clean_pct.replace('.', '_');
+    	message_array.push(create_json(key + '.timers.mean_' + clean_pct ,mean,ts));
+    	message_array.push(create_json(key + '.timers.mean_' + clean_pct ,maxAtThreshold,ts));
+      }
+
+      message_array.push(create_json(key + '.timers.upper' ,max,ts));
+      message_array.push(create_json(key + '.timers.lower' ,min,ts));
+      message_array.push(create_json(key + '.timers.count' ,count,ts));
+      //statString += message;
+
+      numStats += 1;
+    }
+  }
+
+  for (key in gauges) {
+    message_array.push(create_json(key + '.gauges' , gauges[key],ts));
+    numStats += 1;
+  }
+
+  for(var i = 0; i < message_array.length; i++ ) {
+	post_stats(message_array[i].toString())
+  };
+
+};
+
+var create_json = function create_elastic_json(entity, value, timestamp){
+  result = {"entity" : entity , "value" : value , "timestamp" : timestamp} 
+  return JSON.stringify(result);
+}; 
+
+
+var elastic_backend_status = function graphite_status(writeCb) {
+  for (stat in elasticStats) {
+    writeCb(null, 'elastic', stat, elasticStats[stat]);
+  }
+};
+
+exports.init = function graphite_init(startup_time, config, events) {
+  debug = config.debug;
+  elasticHost = config.elasticHost;
+  elasticPort = config.elasticPort;
+  elasticIndex = config.elasticIndex;
+  elasticIndexType = config.elasticIndexType;
+
+  elasticStats.last_flush = startup_time;
+  elasticStats.last_exception = startup_time;
+
+  flushInterval = config.flushInterval;
+
+  events.on('flush', flush_stats);
+  events.on('status', elastic_backend_status);
+
+  return true;
+};
+

--- a/exampleElasticConfig.js
+++ b/exampleElasticConfig.js
@@ -1,0 +1,61 @@
+/*
+
+Required Variables:
+
+  port:             StatsD listening port [default: 8125]
+
+Graphite Required Variables:
+
+(Leave these unset to avoid sending stats to Graphite.
+ Set debug flag and leave these unset to run in 'dry' debug mode -
+ useful for testing statsd clients without a Graphite server.)
+
+  graphiteHost:     hostname or IP of Graphite server
+  graphitePort:     port of Graphite server
+
+Optional Variables:
+
+  backends:         an array of backends to load. Each backend must exist
+                    by name in the directory backends/. If not specified,
+                    the default graphite backend will be loaded.
+  debug:            debug flag [default: false]
+  address:          address to listen on over UDP [default: 0.0.0.0]
+  port:             port to listen for messages on over UDP [default: 8125]
+  mgmt_address:     address to run the management TCP interface on
+                    [default: 0.0.0.0]
+  mgmt_port:        port to run the management TCP interface on [default: 8126]
+  debugInterval:    interval to print debug information [ms, default: 10000]
+  dumpMessages:     log all incoming messages
+  flushInterval:    interval (in ms) to flush to Graphite
+  percentThreshold: for time information, calculate the Nth percentile(s)
+                    (can be a single value or list of floating-point values)
+                    [%, default: 90]
+  keyFlush:         log the most frequently sent keys [object, default: undefined]
+    interval:       how often to log frequent keys [ms, default: 0]
+    percent:        percentage of frequent keys to log [%, default: 100]
+    log:            location of log file for frequent keys [default: STDOUT]
+  
+  ElasticSearch related configurations:
+
+  elasticHost:       	hostname or IP of ElasticSearch server
+  elasticPort:       	port of Elastic Search Server
+  elasticIndex:      	Index of the ElasticSearch server where the metrics are to be saved (_index)
+  elasticIndexType:  	The type of the index to be saved with (_type)
+  elasticFlushInterval: Right now, not being used and is the same as flushInterval, but hope to use this to make the logging to ES over a longer interval than for graphite
+
+  NOTE: backends array includes both graphite and elasticsearch
+
+
+*/
+{
+  port: 8125
+, graphitePort: 2003
+, graphiteHost: "localhost"
+, elasticPort: 9200
+, elasticHost: "localhost"
+, elasticFlushInterval: 10000
+, elasticIndex: "statsd"
+, elasticIndexType: "stats"
+, backends: ['./backends/graphite','./backends/elastic']
+}
+

--- a/utils/httpReq.js
+++ b/utils/httpReq.js
@@ -1,0 +1,64 @@
+// module dependencies
+var http = require('http'),
+    url = require('url');
+
+
+ /**
+  * UrlReq - Wraps the http.request function making it nice for unit testing APIs.
+  * 
+  * @param  {string}   reqUrl   The required url in any form
+  * @param  {object}   options  An options object (this is optional)
+  * @param  {Function} cb       This is passed the 'res' object from your request
+  * 
+  * Credits : https://gist.github.com/1943352
+  * Picked it up from the above URL 
+  */
+exports.urlReq = function(reqUrl, options, cb){
+    if(typeof options === "function"){ cb = options; options = {}; }// incase no options passed in
+
+    // parse url to chunks
+    reqUrl = url.parse(reqUrl);
+
+    // http.request settings
+    var settings = {
+        host: reqUrl.hostname,
+        port: reqUrl.port || 80,
+        path: reqUrl.pathname,
+        headers: options.headers || {},
+        method: options.method || 'GET'
+    };
+
+    // if there are params:
+    if(options.params){
+        settings.headers['Content-Type'] = 'application/json';
+    };
+
+    // MAKE THE REQUEST
+    var req = http.request(settings);
+
+    // if there are params: write them to the request
+    if(options.params){ req.write(options.params) };
+
+    // when the response comes back
+    req.on('response', function(res){
+        res.body = '';
+        res.setEncoding('utf-8');
+
+        // concat chunks
+        res.on('data', function(chunk){ 
+            res.body += chunk ;
+        });
+
+        // when the response has finished
+        res.on('end', function(){
+            
+            // fire callback
+            cb(res.body, res);
+        });
+    });
+
+    // end the request
+    req.end();
+}
+
+


### PR DESCRIPTION
Added a backend for ElasticSearch - http://www.elasticsearch.org/

It would prove useful in having an aggregated history of events and metrics from statsd which can be saved in ElasticSearch. The full text based search functionality provides support for all sorts of queries and analysis. 

backends/elastic.js - The actual backend file
exampleElasticConfig.js - A sample configuration file for ES
utils/httpReq.js - An opensource wrapper for HTTP calls with node.js 
