### PR TITLE
Add missing debhelper to Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 8.0.0)
 
 Package: statsd
 Architecture: all
-Depends: nodejs (>= 0.4.7)
+Depends: ${misc:Depends}, nodejs (>= 0.4.7)
 Description: Stats aggregation daemon
   A network daemon for aggregating statistics (counters and timers),
   rolling them up, then sending them to graphite.


### PR DESCRIPTION
Otherwise, pbuilder complains that the `dh` command can't be found:

```
[...]
I: Building the package
I: Running cd tmp/buildd/*/ && dpkg-buildpackage -us -uc  -sa -i'(?:^|/)\.git(attributes)?(?:$|/.*$)' -I.git  -sa -i'(?:^|/)\.git(attributes)?(?:$|/.*$)' -I.git  -rfakeroot
dpkg-buildpackage: export CFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export CPPFLAGS from dpkg-buildflags (origin: vendor): 
dpkg-buildpackage: export CXXFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export FFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export LDFLAGS from dpkg-buildflags (origin: vendor): 
dpkg-buildpackage: source package statsd
dpkg-buildpackage: source version 0.0.3
dpkg-buildpackage: source changed by Stephen Koenig <heph@bittorrent.com>
 dpkg-source -i(?:^|/)\.git(attributes)?(?:$|/.*$) -I.git -i(?:^|/)\.git(attributes)?(?:$|/.*$) -I.git --before-build statsd-0.0.3
dpkg-buildpackage: host architecture amd64
 fakeroot debian/rules clean
dh clean
make: dh: Command not found
make: *** [clean] Error 127
dpkg-buildpackage: error: fakeroot debian/rules clean gave error exit status 2
E: Failed autobuilding of package
[...]
```
