### PR TITLE
LSB compliant init script

### DIFF
--- a/debian/statsd.init
+++ b/debian/statsd.init
@@ -1,4 +1,11 @@
 #! /bin/sh
+### BEGIN INIT INFO
+# Provides:          statsd
+# Required-Start:    $network $local_fs
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+### END INIT INFO
 
 # Do NOT "set -e"
 


### PR DESCRIPTION
By adding the missing `INIT INFO` header
