### PR TITLE
Make 'gauges' and 'timers' key prefixes configurable.

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -19,6 +19,8 @@ var debug;
 var flushInterval;
 var graphiteHost;
 var graphitePort;
+var gaugePrefix;
+var timerPrefix;
 
 var graphiteStats = {};
 
@@ -104,19 +106,19 @@ var flush_stats = function graphite_flush(ts, metrics) {
 
         var clean_pct = '' + pct;
         clean_pct.replace('.', '_');
-        message += 'stats.timers.' + key + '.mean_'  + clean_pct + ' ' + mean           + ' ' + ts + "\n";
-        message += 'stats.timers.' + key + '.upper_' + clean_pct + ' ' + maxAtThreshold + ' ' + ts + "\n";
-        message += 'stats.timers.' + key + '.sum_' + clean_pct + ' ' + sum + ' ' + ts + "\n";
+        message += 'stats.' + timerPrefix + key + '.mean_'  + clean_pct + ' ' + mean           + ' ' + ts + "\n";
+        message += 'stats.' + timerPrefix + key + '.upper_' + clean_pct + ' ' + maxAtThreshold + ' ' + ts + "\n";
+        message += 'stats.' + timerPrefix + key + '.sum_' + clean_pct + ' ' + sum + ' ' + ts + "\n";
       }
 
       sum = cumulativeValues[count-1];
       mean = sum / count;
 
-      message += 'stats.timers.' + key + '.upper ' + max   + ' ' + ts + "\n";
-      message += 'stats.timers.' + key + '.lower ' + min   + ' ' + ts + "\n";
-      message += 'stats.timers.' + key + '.count ' + count + ' ' + ts + "\n";
-      message += 'stats.timers.' + key + '.sum ' + sum  + ' ' + ts + "\n";
-      message += 'stats.timers.' + key + '.mean ' + mean + ' ' + ts + "\n";
+      message += 'stats.' + timerPrefix + key + '.upper ' + max   + ' ' + ts + "\n";
+      message += 'stats.' + timerPrefix + key + '.lower ' + min   + ' ' + ts + "\n";
+      message += 'stats.' + timerPrefix + key + '.count ' + count + ' ' + ts + "\n";
+      message += 'stats.' + timerPrefix + key + '.sum ' + sum  + ' ' + ts + "\n";
+      message += 'stats.' + timerPrefix + key + '.mean ' + mean + ' ' + ts + "\n";
       statString += message;
 
       numStats += 1;
@@ -124,7 +126,7 @@ var flush_stats = function graphite_flush(ts, metrics) {
   }
 
   for (key in gauges) {
-    statString += 'stats.gauges.' + key + ' ' + gauges[key] + ' ' + ts + "\n";
+    statString += 'stats.' + gaugePrefix + key + ' ' + gauges[key] + ' ' + ts + "\n";
     numStats += 1;
   }
 
@@ -143,6 +145,10 @@ exports.init = function graphite_init(startup_time, config, events) {
   debug = config.debug;
   graphiteHost = config.graphiteHost;
   graphitePort = config.graphitePort;
+  timerPrefix = config.timerPrefix;
+  gaugePrefix = config.gaugePrefix;;
+  if (timerPrefix == null) { timerPrefix = 'timers.'; }
+  if (gaugePrefix == null) { gaugePrefix = 'gauges.'; }
 
   graphiteStats.last_flush = startup_time;
   graphiteStats.last_exception = startup_time;


### PR DESCRIPTION
Added configuration items to control the key prefixes for gauges and timers.  Can be used to eliminate the prefixes entirely.  Defaults are set to 'gauges.' and 'timers.' to maintain compatability
