### PR TITLE
Fixed locale bug in Java client

### DIFF
--- a/examples/StatsdClient.java
+++ b/examples/StatsdClient.java
@@ -34,6 +34,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
+import java.util.Locale;
 import java.util.Random;
 
 import org.apache.log4j.Logger;
@@ -59,7 +60,7 @@ public class StatsdClient {
 	}
 
 	public boolean timing(String key, int value, double sampleRate) {
-		return send(sampleRate, String.format("%s:%d|ms", key, value));
+		return send(sampleRate, String.format(Locale.ENGLISH, "%s:%d|ms", key, value));
 	}
 
 	public boolean decrement(String key) {
@@ -98,14 +99,14 @@ public class StatsdClient {
 	}
 
 	public boolean increment(String key, int magnitude, double sampleRate) {
-		String stat = String.format("%s:%s|c", key, magnitude);
+		String stat = String.format(Locale.ENGLISH, "%s:%s|c", key, magnitude);
 		return send(sampleRate, stat);
 	}
 
 	public boolean increment(int magnitude, double sampleRate, String... keys) {
 		String[] stats = new String[keys.length];
 		for (int i = 0; i < keys.length; i++) {
-			stats[i] = String.format("%s:%s|c", keys[i], magnitude);
+			stats[i] = String.format(Locale.ENGLISH, "%s:%s|c", keys[i], magnitude);
 		}
 		return send(sampleRate, stats);
 	}
@@ -116,7 +117,7 @@ public class StatsdClient {
 		if (sampleRate < 1.0) {
 			for (String stat : stats) {
 				if (RNG.nextDouble() <= sampleRate) {
-					stat = String.format("%s|@%f", stat, sampleRate);
+					stat = String.format(Locale.ENGLISH, "%s|@%f", stat, sampleRate);
 					if (doSend(stat)) {
 						retval = true;
 					}


### PR DESCRIPTION
Specifically, String.format() is locale dependent, so if the system locale is a country that uses commas for decimal places, for example, Germany, then when the sample rate is formatted, you end up with "0,1" instead of "0.1".  Solution is to use Locale.ENGLISH everywhere.
