### PR TITLE
debian/statsd.init: fix the start-stop-daemon --test line.

### DIFF
--- a/debian/statsd.init
+++ b/debian/statsd.init
@@ -48,7 +48,7 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+	start-stop-daemon --start --quiet -m --pidfile $PIDFILE --startas $DAEMON --background --test > /dev/null \
 		|| return 1
 	start-stop-daemon --start --quiet -m --pidfile $PIDFILE --startas $DAEMON --background -- \
 		$DAEMON_ARGS > /dev/null 2> /var/log/$NAME-stderr.log \


### PR DESCRIPTION
give the same arguments as the real start-stop-daemon line (`startas`
instead of `exec`), otherwise the daemon is not properly detected as started.
