### PR TITLE
Get unit tests working again (reflect the new statsd.numStats value)

### DIFF
--- a/test/graphite_tests.js
+++ b/test/graphite_tests.js
@@ -149,7 +149,7 @@ module.exports = {
           return data;
         });
         test.ok(_.include(_.map(entries,function(x) { return _.keys(x)[0] }),'statsd.numStats'),'graphite output includes numStats');
-        test.equal(_.find(entries, function(x) { return _.keys(x)[0] == 'statsd.numStats' })['statsd.numStats'],0);
+        test.equal(_.find(entries, function(x) { return _.keys(x)[0] == 'statsd.numStats' })['statsd.numStats'],2);
         test.done();
       });
     });
@@ -172,7 +172,7 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 1);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
             };
             test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 1');
 
@@ -205,7 +205,7 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 1);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
             };
             test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 1');
 


### PR DESCRIPTION
The unit tests begin failing at commit 8f202fdb.

I believe this is because, statsd is now (as of that commit) keeping its own stats about its own workings. Thus `statsd.numStats` increases to reflect that. So the tests need to reflect that reflection.
