### PR TITLE
add lib/*.js to list of files that needs to be installed for debian package

### DIFF
--- a/debian/statsd.install
+++ b/debian/statsd.install
@@ -1,5 +1,6 @@
 stats.js	/usr/share/statsd
 config.js	/usr/share/statsd
+lib/*.js /usr/share/statsd/lib
 backends/*.js  /usr/share/statsd/backends
 debian/localConfig.js	/etc/statsd
 debian/scripts/start	/usr/share/statsd/scripts


### PR DESCRIPTION
When i tried to package node one a ubuntu 12.04 server, the installed package reports missing of lib/logger.js file.

```
module.js:340
    throw err;
          ^
Error: Cannot find module './lib/logger'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (/usr/share/statsd/stats.js:7:14)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
```

The change was introduced in commit 626277067bbf54da93a6df11f9f1dc68dbcceb14
