### PR TITLE
Improved the quality of randomness used for sampling.

### DIFF
--- a/examples/csharp_example.cs
+++ b/examples/csharp_example.cs
@@ -8,7 +8,17 @@ namespace Statsd
     public class StatsdPipe : IDisposable
     {
         private readonly UdpClient udpClient;
-        private readonly Random random = new Random();
+
+        [ThreadStatic]
+        private static Random random;
+
+        private static Random Random
+        {
+            get
+            {
+                return random ?? (random = new Random());
+            }
+        }
 
         public StatsdPipe(string host, int port)
         {
@@ -101,7 +111,7 @@ namespace Statsd
             {
                 foreach (var stat in stats)
                 {
-                    if (random.NextDouble() <= sampleRate)
+                    if (Random.NextDouble() <= sampleRate)
                     {
                         var statFormatted = String.Format("{0}|@{1:f}", stat, sampleRate);
                         if (DoSend(statFormatted))


### PR DESCRIPTION
The previous version had issues with rapidly creating and disposing of StatsdPipe instances.

If, say, 100 were created in the same millisecond, they would all be given the same Random seed.

In this version, we use ThreadStatic storage to reduce the number of Random instances created, maintain thread safety, and allow randomness to vary much more quickly than per-millisecond.
