### PR TITLE
Make it clearer that sampling is only for counters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Counting
 
 This is a simple counter. Add 1 to the "gorets" bucket. It stays in memory until the flush interval `config.flushInterval`.
 
+### Sampling
+
+    gorets:1|c|@0.1
+
+Tells StatsD that this counter is being sent sampled every 1/10th of the time.
 
 Timing
 ------
@@ -47,13 +52,6 @@ generate the following list of stats for each threshold:
 
 Where `$KEY` is the key you stats key you specify when sending to statsd, and
 `$PCT` is the percentile threshold.
-
-Sampling
---------
-
-    gorets:1|c|@0.1
-
-Tells StatsD that this counter is being sent sampled every 1/10th of the time.
 
 Gauges
 ------


### PR DESCRIPTION
Sampling [only applies to counters](https://github.com/etsy/statsd/blob/5a36ca09/stats.js#L142-150) but the README wasn't clear on this.  The text reads "Tells StatsD that this _counter_ is being sent sampled" but the block is in between sections about timing and gauges, and at the same header level.

This is just a simple movement of text, and a change in the title style, to make it more obvious that sampling is only applicable to counters.
