### PR TITLE
Fixing small typo in golang example.

### DIFF
--- a/examples/statsd.go
+++ b/examples/statsd.go
@@ -19,7 +19,7 @@ type StatsdClient struct {
  * Usage:
  *
  * import "statsd"
- * client := statsd.Net('localhost', 8125)
+ * client := statsd.New('localhost', 8125)
  **/
 func New(host string, port int) *StatsdClient {
 	client := StatsdClient{Host: host, Port: port}


### PR DESCRIPTION
s/Net/New/
