### PR TITLE
Fix for config.js, fs.watchFile doesn't work

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@ var Configurator = function (file) {
 
   this.updateConfig();
 
-  fs.watchFile(file, function (curr, prev) {
+  fs.watch(file, function (curr, prev) {
     if (curr.ino != prev.ino) { self.updateConfig(); }
   });
 };


### PR DESCRIPTION
When running I get the following error:

fs.js:747
    throw new Error('use fs.watch api instead');
          ^
Error: use fs.watch api instead
    at Object.watchFile (fs.js:747:11)
    at new <anonymous> (c:\git\platform-statsd\config.js:24:6)
    at Object.configFile (c:\git\platform-statsd\config.js:34:16)
    at Object.<anonymous> (c:\git\platform-statsd\stats.js:77:8)
    at Module._compile (module.js:446:26)
    at Object..js (module.js:464:10)
    at Module.load (module.js:353:31)
    at Function._load (module.js:311:12)
    at Array.0 (module.js:484:10)
    at EventEmitter._tickCallback (node.js:190:38)

Using fs.watch fixes this issue.
