### PR TITLE
Increments bad_lines_seen when sampleRate bit does not match regex

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -140,8 +140,15 @@ config.configFile(process.argv[2], function (config, oldConfig) {
           } else if (fields[1].trim() == "g") {
             gauges[key] = Number(fields[0] || 0);
           } else {
-            if (fields[2] && fields[2].match(/^@([\d\.]+)/)) {
-              sampleRate = Number(fields[2].match(/^@([\d\.]+)/)[1]);
+            if (fields[2]) {
+              if (fields[2].match(/^@([\d\.]+)/)) {
+                sampleRate = Number(fields[2].match(/^@([\d\.]+)/)[1]);
+              } else {
+                l.log('Bad line: ' + fields + ' in msg "' + metrics[midx] +'"; has invalid sample rate');
+                counters["statsd.bad_lines_seen"]++;
+                stats['messages']['bad_lines_seen']++;
+                continue;
+              }
             }
             if (! counters[key]) {
               counters[key] = 0;


### PR DESCRIPTION
Not sure if this is what the intent behind "bad_lines_seen" is, but I know it definitely would've helped me when troubleshooting a problem sending stats from my (albeit buggy) customer client code.

This change will write to the log and increment bad_lines_seen if the bit in the |-delimited stat does not match the decimal regex.
