### PR TITLE
Fixes some errors

### DIFF
--- a/examples/python_example.py
+++ b/examples/python_example.py
@@ -2,15 +2,15 @@
 
 # Steve Ivy <steveivy@gmail.com>
 # http://monkinetic.com
- 
+
 # this file expects local_settings.py to be in the same dir, with statsd host and port information:
-# 
+#
 # statsd_host = 'localhost'
 # statsd_port = 8125
 
 # Sends statistics to the stats daemon over UDP
 class Statsd(object):
-    
+
     @staticmethod
     def timing(stat, time, sample_rate=1):
         """
@@ -38,7 +38,7 @@ class Statsd(object):
         >>> Statsd.decrement('some.int')
         """
         Statsd.update_stats(stats, -1, sample_rate)
-    
+
     @staticmethod
     def update_stats(stats, delta=1, sampleRate=1):
         """
@@ -52,7 +52,7 @@ class Statsd(object):
             data[stat] = "%s|c" % delta
 
         Statsd.send(data, sampleRate)
-    
+
     @staticmethod
     def send(data, sample_rate=1):
         """
@@ -65,9 +65,9 @@ class Statsd(object):
             addr=(host, port)
         except:
             exit(1)
-        
+
         sampled_data = {}
-        
+
         if(sample_rate < 1):
             import random
             if random.random() <= sample_rate:
@@ -76,8 +76,8 @@ class Statsd(object):
                     sampled_data[stat] = "%s|@%s" %(value, sample_rate)
         else:
             sampled_data=data
-        
-        from socket import *
+
+        from socket import socket, AF_INET, SOCK_DGRAM
         udp_sock = socket(AF_INET, SOCK_DGRAM)
         try:
             for stat in sampled_data.keys():


### PR DESCRIPTION
The python example file had a couple of problems, one was that `Error` exception was never defined so whenever one would hit that code an unrelated exception would be raised. This was removed, following the _catch all_ from other blocks (not necessarily happy about it but it fixes the problem).

The other issue is that on Python >= 2.7 importing `*` causes a SyntaxError. There is no need to import everything if all you are using is 3 modules, so this pull request changes that as well.
