### PR TITLE
Repeater support

### DIFF
--- a/backends/repeater.js
+++ b/backends/repeater.js
@@ -1,0 +1,29 @@
+var util = require('util'),
+    dgram = require('dgram');
+
+function RepeaterBackend(startupTime, config, emitter){
+  var self = this;
+  this.config = config.repeater || [];
+  this.sock = dgram.createSocket('udp4');
+
+  // attach
+  emitter.on('packet', function(packet, rinfo) { self.process(packet, rinfo); });
+};
+
+RepeaterBackend.prototype.process = function(packet, rinfo) {
+  var self = this;
+  hosts = self.config;
+  for(var i=0; i<hosts.length; i++) {
+    self.sock.send(packet,0,packet.length,hosts[i].port,hosts[i].host,
+                   function(err,bytes) {
+      if (err) {
+        console.log(err);
+      }
+    });
+  }
+};
+
+exports.init = function(startupTime, config, events) {
+  var instance = new RepeaterBackend(startupTime, config, events);
+  return true;
+};

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -44,9 +44,16 @@ Optional Variables:
     application:    name of the application for syslog [string, default: statsd]
     level:          log level for [node-]syslog [string, default: LOG_INFO]
 
+  repeater:         an array of hashes of the for host: and port:
+                    that details other statsd servers to which the received
+                    packets should be "repeated" (duplicated to).
+                    e.g. [ { host: '10.10.10.10', port: 8125 },
+                           { host: 'observer', port: 88125 } ]
 */
 {
   graphitePort: 2003
 , graphiteHost: "graphite.host.com"
 , port: 8125
+, backends: [ "./backends/repeater" ]
+, repeater: [ { host: "10.8.3.214", port: 8125 } ]
 }

--- a/stats.js
+++ b/stats.js
@@ -99,6 +99,7 @@ config.configFile(process.argv[2], function (config, oldConfig) {
     var keyFlushInterval = Number((config.keyFlush && config.keyFlush.interval) || 0);
 
     server = dgram.createSocket('udp4', function (msg, rinfo) {
+      backendEvents.emit('packet', msg, rinfo);
       counters["statsd.packets_received"]++;
       var metrics = msg.toString().split("\n");
 


### PR DESCRIPTION
Add a emit point with raw packet information. Add a module that uses it.

This allows a statsd server to forward packets to an arbitrary number of upstream statsd servers.
