### PR TITLE
Relax metric name sanitation based on a configuration flag

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -21,6 +21,12 @@ Optional Variables:
   debug:            debug flag [default: false]
   address:          address to listen on over UDP [default: 0.0.0.0]
   port:             port to listen for messages on over UDP [default: 8125]
+
+  relaxMetricNameSanitation:
+                    allow '/' characters in metric names to pass through to the
+                    backend [default: false] - may cause undesirable behavior in
+                    the graphite backend
+
   mgmt_address:     address to run the management TCP interface on
                     [default: 0.0.0.0]
   mgmt_port:        port to run the management TCP interface on [default: 8126]

--- a/stats.js
+++ b/stats.js
@@ -117,10 +117,21 @@ config.configFile(process.argv[2], function (config, oldConfig) {
           l.log(metrics[midx].toString());
         }
         var bits = metrics[midx].toString().split(':');
-        var key = bits.shift()
+        
+        var key = '';
+        
+        if (config.relaxMetricNameSanitation) {
+          // leave '/' characters intact in the metric name
+          key = bits.shift()
+                      .replace(/\s+/g, '_')
+                      .replace(/[^a-zA-Z_\/\-0-9\.]/g, '');
+        }
+        else {
+          key = bits.shift()
                       .replace(/\s+/g, '_')
                       .replace(/\//g, '-')
                       .replace(/[^a-zA-Z_\-0-9\.]/g, '');
+        }
 
         if (keyFlushInterval > 0) {
           if (! keyCounter[key]) {


### PR DESCRIPTION
This is not a general fix for https://github.com/etsy/statsd/issues/110, but it does provide a way to accomplish one of the use cases described in the issue:

> For example, in the case of the Librato backend we would like a way to specify a 
> custom source parameter on a stat by stat basis. One thought would be to use a 
> prefix character, like (/), to separate the source name from the metric name

This flag can be used in conjunction with this patch to the librato-statsd-backend:
https://github.com/librato/statsd-librato-backend/pull/8
