### PR TITLE
Move stat key name sanitization to Graphite backend.

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -34,6 +34,7 @@ var prefixTimer;
 var prefixGauge;
 var prefixSet;
 var globalSuffix;
+var globalKeySanitize = true;
 
 // set up namespaces
 var legacyNamespace  = true;
@@ -98,15 +99,27 @@ var flush_stats = function graphite_flush(ts, metrics) {
   var timer_data = metrics.timer_data;
   var statsd_metrics = metrics.statsd_metrics;
 
+  // Sanitize key for graphite if not done globally
+  function sk(key) {
+    if (globalKeySanitize) {
+      return key;
+    } else {
+      return key.replace(/\s+/g, '_')
+                .replace(/\//g, '-')
+                .replace(/[^a-zA-Z_\-0-9\.]/g, '');
+    }
+  };
+
   for (key in counters) {
-    var namespace = counterNamespace.concat(key);
     var value = counters[key];
     var valuePerSecond = counter_rates[key]; // pre-calculated "per second" rate
+    var keyName = sk(key);
+    var namespace = counterNamespace.concat(keyName);
 
     if (legacyNamespace === true) {
       statString += namespace.join(".")   + globalSuffix + valuePerSecond + ts_suffix;
       if (flush_counts) {
-        statString += 'stats_counts.' + key + globalSuffix + value + ts_suffix;
+        statString += 'stats_counts.' + keyName + globalSuffix + value + ts_suffix;
       }
     } else {
       statString += namespace.concat('rate').join(".")  + globalSuffix + valuePerSecond + ts_suffix;
@@ -119,8 +132,9 @@ var flush_stats = function graphite_flush(ts, metrics) {
   }
 
   for (key in timer_data) {
-    var namespace = timerNamespace.concat(key);
+    var namespace = timerNamespace.concat(sk(key));
     var the_key = namespace.join(".");
+
     for (timer_data_key in timer_data[key]) {
       if (typeof(timer_data[key][timer_data_key]) === 'number') {
         statString += the_key + '.' + timer_data_key + globalSuffix + timer_data[key][timer_data_key] + ts_suffix;
@@ -138,13 +152,13 @@ var flush_stats = function graphite_flush(ts, metrics) {
   }
 
   for (key in gauges) {
-    var namespace = gaugesNamespace.concat(key);
+    var namespace = gaugesNamespace.concat(sk(key));
     statString += namespace.join(".") + globalSuffix + gauges[key] + ts_suffix;
     numStats += 1;
   }
 
   for (key in sets) {
-    var namespace = setsNamespace.concat(key);
+    var namespace = setsNamespace.concat(sk(key));
     statString += namespace.join(".") + '.count' + globalSuffix + sets[key].values().length + ts_suffix;
     numStats += 1;
   }
@@ -237,6 +251,10 @@ exports.init = function graphite_init(startup_time, config, events) {
   graphiteStats.last_exception = startup_time;
   graphiteStats.flush_time = 0;
   graphiteStats.flush_length = 0;
+
+  if (config.keyNameSanitize !== undefined) {
+    globalKeySanitize = config.keyNameSanitize;
+  }
 
   flushInterval = config.flushInterval;
 

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -52,6 +52,9 @@ Optional Variables:
   deleteCounters:   don't send values to graphite for inactive counters, as opposed to sending 0 [default: false]
   prefixStats:      prefix to use for the statsd statistics data for this running instance of statsd [default: statsd]
                     applies to both legacy and new namespacing
+  keyNameSanitize:  sanitize all stat names on ingress [default: true]
+                    If disabled, it is up to the backends to sanitize keynames
+                    as appropriate per their storage requirements.
 
   console:
     prettyprint:    whether to prettyprint the console backend

--- a/test/graphite_tests.js
+++ b/test/graphite_tests.js
@@ -358,5 +358,24 @@ module.exports = {
         });
       });
     });
+  },
+
+  metric_names_are_sanitized: function(test) {
+    var me = this;
+    this.acceptor.once('connection', function(c) {
+      statsd_send('fo/o:250|c',me.sock,'127.0.0.1',8125,function(){
+        statsd_send('b ar:250|c',me.sock,'127.0.0.1',8125,function(){
+          statsd_send('foo+bar:250|c',me.sock,'127.0.0.1',8125,function(){
+            collect_for(me.acceptor, me.myflush, function(strings){
+              var str = strings.join();
+              test.ok(str.indexOf('fo-o') !== -1, "Did not map 'fo/o' => 'fo-o'");
+              test.ok(str.indexOf('b_ar') !== -1, "Did not map 'b ar' => 'b_ar'");
+              test.ok(str.indexOf('foobar') !== -1, "Did not map 'foo+bar' => 'foobar'");
+              test.done();
+            });
+          });
+        });
+      });
+    });
   }
 }


### PR DESCRIPTION
Taking a stab at moving the metric name sanitization to the backend, as described originally in #110 (also refs #154).

This moves the Graphite-specific stat name regular expressions to the Graphite backend. Other backends should implement similar stat name expression cleanups based on their permitted character codes.

One issue that is not handled: Since the original code was performing these name changes at the time of ingress, it was possible that two stat reports could map to the same name. For example, the following two packets would map to the same timing metric:

```
glork:320|ms
gl+ork:320|ms
```

With this patch, these metrics will be tracked separately, but will both be submitted to Graphite using the same name "glork". Therefore, the second metric will likely overwrite the first one. It's not clear if this is actually behavior users are (or should be) depending on. The backend could go through and merge all metrics whose names map to the same key after sanitization, however, this might be tricky for metrics like gauges that track the last value (would require a timestamp). Thoughts?
