### PR TITLE
Fix a typo in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 StatsD Example Clients
 ======================
 
-Here's a bunch of example code contributed by the communinty for interfacing with statsd in a variety of languages.
+Here's a bunch of example code contributed by the community for interfacing with statsd in a variety of languages.
 
     Etsy/StatsD.pm    - perl module
     perl-example.pl   - perl using Etsy/StatsD module


### PR DESCRIPTION
I realise that this is a one character change, but GitHub makes it easy.
