### PR TITLE
fix locale issue in php

### DIFF
--- a/examples/php-example.php
+++ b/examples/php-example.php
@@ -15,6 +15,7 @@ class StatsD {
      * @param float|1 $sampleRate the rate (0-1) for sampling.
      **/
     public static function timing($stat, $time, $sampleRate=1) {
+        $time = number_format($time, 4, '.', '');
         StatsD::send(array($stat => "$time|ms"), $sampleRate);
     }
 


### PR DESCRIPTION
when php use not common locale (RU for example) simple
convertion float to string may look like
13,4343
21 1212,00
12'212'000.33
and udp request send strings like this
12,2323|ms and statsd can't correctly parse such strings
