### PR TITLE
Modify debian/statsd.install after config.js file was moved to lib folder

### DIFF
--- a/debian/statsd.install
+++ b/debian/statsd.install
@@ -1,5 +1,4 @@
 stats.js	/usr/share/statsd
-config.js	/usr/share/statsd
 lib/*.js /usr/share/statsd/lib
 backends/*.js  /usr/share/statsd/backends
 debian/localConfig.js	/etc/statsd


### PR DESCRIPTION
After commit https://github.com/etsy/statsd/commit/e0daf54adafdc0bc8c622957d56c7eb5467f2c6e debian package creation fails with error:
cp: cannot stat `debian/tmp/config.js': No such file or directory
dh_install: cp -a debian/tmp/config.js debian/statsd//usr/share/statsd/ returned exit code 1
make: **\* [binary] Error 2
dpkg-buildpackage: error: debian/rules binary gave error exit status 2
---- End output of dpkg-buildpackage -us -uc ----

Fixing this error.
## Thanks

Vadim
