### PR TITLE
install lib files, set current dir for daemon to allow require(./lib/)

### DIFF
--- a/debian/statsd.init
+++ b/debian/statsd.init
@@ -25,6 +25,7 @@ DAEMON=$NODE_BIN
 DAEMON_ARGS="/usr/share/statsd/stats.js /etc/statsd/localConfig.js 2>&1 >> /var/log/statsd/statsd.log "
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
+CHDIR="/usr/share/statsd"
 
 # Exit if the package is not installed
 # [ -x "$DAEMON" ] || exit 0
@@ -50,7 +51,7 @@ do_start()
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet -m --pidfile $PIDFILE --startas $DAEMON --background --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet -m --pidfile $PIDFILE --startas $DAEMON --background -- \
+	start-stop-daemon --start --quiet -m --pidfile $PIDFILE --startas $DAEMON --background --chdir $CHDIR -- \
 		$DAEMON_ARGS > /dev/null 2> /var/log/$NAME-stderr.log \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready

--- a/debian/statsd.install
+++ b/debian/statsd.install
@@ -1,5 +1,6 @@
 stats.js	/usr/share/statsd
 lib/*.js /usr/share/statsd/lib
 backends/*.js  /usr/share/statsd/backends
+lib/*.js  /usr/share/statsd/lib
 debian/localConfig.js	/etc/statsd
 debian/scripts/start	/usr/share/statsd/scripts

--- a/debian/statsd.upstart
+++ b/debian/statsd.upstart
@@ -5,8 +5,7 @@ start on startup
 stop on shutdown
 
 script
-    # We found $HOME is needed. Without it, we ran into problems
-    export HOME="/root"
+    chdir /usr/share/statsd
 
     exec sudo -u nobody /usr/share/statsd/scripts/start
 end script


### PR DESCRIPTION
Current debian init scripts (both upstart and non-upstart one) don't set current dir but stats.js expects lib folder to reside in current dir.
