### PR TITLE
Fixes Issues #188 - repeater can be configured for udp6, defaults to udp4

### DIFF
--- a/backends/repeater.js
+++ b/backends/repeater.js
@@ -4,7 +4,9 @@ var util = require('util'),
 function RepeaterBackend(startupTime, config, emitter){
   var self = this;
   this.config = config.repeater || [];
-  this.sock = dgram.createSocket('udp4');
+  this.sock = (config.repeaterProtocol == 'udp6') ?
+        dgram.createSocket('udp6') :
+        dgram.createSocket('udp4');
 
   // attach
   emitter.on('packet', function(packet, rinfo) { self.process(packet, rinfo); });

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -49,6 +49,9 @@ Optional Variables:
                     packets should be "repeated" (duplicated to).
                     e.g. [ { host: '10.10.10.10', port: 8125 },
                            { host: 'observer', port: 88125 } ]
+
+  repeaterProtocol: whether to use udp4 or udp4 for repeaters.
+                    ["udp4" or "udp6", default: "udp4"]
 */
 {
   graphitePort: 2003
@@ -56,4 +59,5 @@ Optional Variables:
 , port: 8125
 , backends: [ "./backends/graphite" ]
 , repeater: [ { host: "10.8.3.214", port: 8125 } ]
+, repeaterProtocol: "udp4"
 }


### PR DESCRIPTION
Although repeaters default to udp4, this allows users to configure for udp6.
