### PR TITLE
package.json "engines"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node-syslog":"1.1.3",
     "winser": "=0.0.11"
   },
-  "engine": {
+  "engines": {
     "node" : ">=0.4"
   },
   "bin": { "statsd": "./bin/statsd" }


### PR DESCRIPTION
https://npmjs.org/doc/json.html specifies "engines" while the current code uses the "engine" key. This causes problems e.g. on Heroku/Pogoapp using the node.js buildpack, which looks for "engines" key to figure out what version of node to vendor in
