### PR TITLE
document reset-to-0 behavior for counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This is a simple counter. Add 1 to the "gorets" bucket.
 At each flush the current count is sent and reset to 0.
 If the count at flush is 0 then you can opt to send no metric at all for
 this counter, by setting `config.deleteCounters` (applies only to graphite
-backend)
+backend).  Statsd will send both the rate as well as the count at each flush.
 
 ### Sampling
 


### PR DESCRIPTION
also:
- document config.deleteCounters in readme
- move the config.flushInterval bit up to the part about flushing

this fixes #140
