### PR TITLE
Use counter_rates in graphite backent

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -85,7 +85,7 @@ var flush_stats = function graphite_flush(ts, metrics) {
   for (key in counters) {
     var namespace = counterNamespace.concat(key);
     var value = counters[key];
-    var valuePerSecond = value / (flushInterval / 1000); // calculate "per second" rate
+    var valuePerSecond = counter_rates[key]; // pre-calculated "per second" rate
 
     if (legacyNamespace === true) {
       statString += namespace.join(".")   + ' ' + valuePerSecond + ts_suffix;


### PR DESCRIPTION
Revert to using counter_rates after the namespace commit. 

If this is overkill or confusing i can pull the counter_rates out of process_metrics.js 
