### PR TITLE
skip setting intermediate variable

### DIFF
--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -12,8 +12,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
       var value = counters[key];
 
       // calculate "per second" rate
-      var valuePerSecond = value / (flushInterval / 1000);
-      counter_rates[key] = valuePerSecond;
+      counter_rates[key] = value / (flushInterval / 1000);
     }
 
     for (key in timers) {


### PR DESCRIPTION
If we aren't going to pull this logic out pending the response to pull #207 we probably don't need to do a double hop through the valuePerSecond variable.
