### PR TITLE
exampleConfig has extras turned on, and uses real hosts/IPs

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -64,9 +64,9 @@ Optional Variables:
 */
 {
   graphitePort: 2003
-, graphiteHost: "graphite.host.com"
+, graphiteHost: "graphite.example.com"
 , port: 8125
 , backends: [ "./backends/graphite" ]
-, repeater: [ { host: "10.8.3.214", port: 8125 } ]
-, repeaterProtocol: "udp4"
+//, repeater: [ { host: "graphiterepeater.example.com", port: 8125 } ]
+//, repeaterProtocol: "udp4"
 }


### PR DESCRIPTION
exampleConfig uses real hostnames and real IP addresses - it also has the repeater configuration enabled by default (...pointing at someone elses machine).   

While this is "example" it's frequently used as a starting point for new users and for rpm packages (and probably others) as a starting point.

switched to example.com hostnames, and commented out (but didn't remove - it is example config) the repeater section.
