### PR TITLE
Fix broken python example

### DIFF
--- a/examples/python_example.py
+++ b/examples/python_example.py
@@ -45,7 +45,7 @@ class StatsdClient(object):
         >>> client = StatsdClient()
         >>> client.update_stats('some.int', 10)
         """
-        if isinstance(stats, list):
+        if not isinstance(stats, list):
             stats = [stats]
         data = {}
         for stat in stats:


### PR DESCRIPTION
As it stands, the python example will create a stat for each of the letters in the string `python example` because it steps through each character in the example and sends a stat for each. This change seems to be in line with what was meant: force a single-string into a list when it's not already a list and don't try to iterate over a string character by character.
