### PR TITLE
Stability fix

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -193,6 +193,10 @@ config.configFile(process.argv[2], function (config, oldConfig) {
     mgmtServer = net.createServer(function(stream) {
       stream.setEncoding('ascii');
 
+      stream.on('error', function(err) {
+        l.log('Caught ' + err +', Moving on')
+      });
+
       stream.on('data', function(data) {
         var cmdline = data.trim().split(" ");
         var cmd = cmdline.shift();


### PR DESCRIPTION
This resolves an issue where a random TCP client goes away before a response
is sent from the server. The resulting exception was not handled, and would
cause node.js to crash.

The log file would show this message as a result:
node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: write ECONNRESET
    at errnoException (net.js:642:11)
    at Object.afterWrite [as oncomplete](net.js:480:18)
