### PR TITLE
add per second rate for timer sum and timer count

### DIFF
--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -15,6 +15,8 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
       counter_rates[key] = value / (flushInterval / 1000);
     }
 
+	var countrate;
+	var rate;
     for (key in timers) {
       if (timers[key].length > 0) {
         timer_data[key] = {};
@@ -57,6 +59,11 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         sum = cumulativeValues[count-1];
         mean = sum / count;
 
+		// per second rates for sum and count
+		sumrate = sum / (flushInterval / 1000) ;
+        countrate = count / (flushInterval / 1000) ;
+
+
         var sumOfDiffs = 0;
         for (var i = 0; i < count; i++) {
            sumOfDiffs += (values[i] - mean) * (values[i] - mean);
@@ -66,7 +73,9 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         current_timer_data["upper"] = max;
         current_timer_data["lower"] = min;
         current_timer_data["count"] = count;
+        current_timer_data["count_rate"] = countrate;
         current_timer_data["sum"] = sum;
+        current_timer_data["sum_rate"] = sumrate;
         current_timer_data["mean"] = mean;
 
         timer_data[key] = current_timer_data;


### PR DESCRIPTION
add count_rate and sum_rate to timers - gives a built in per second rate for these.

I'm open to discussion on this one - I didn't add anything to the readme because count and sum aren't documented there at all yet.....

Also don't know if this change (which would only add new data for users who get it in an upgrade and should be non impacting, other than disk space/carbon load) should have a config to turn it on, or default it on and be able to turn it on, or or or...

open to discussion.  but works and passes unit tests.  should merge clean into my other PRs.

should note that sum_rate probably doesn't make a lot of sense for "timers" that are actually measurements of time.... but if you were using timers as (say) counters with more features..  I think count_rate still makes sense though since it gives you a rate of reporters for the interval...
