### PR TITLE
Configurable resetting of gauges to 0 on flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ StatsD now also supports gauges, arbitrary values, which can be recorded.
 
     gaugor:333|g
 
+The gauge value is retained beyond a flush. In case the client stops updating the guage, 
+StatsD continues to send the last received value to the backend. You can choose to reset 
+gauges to 0 upon a flush, by setting `config.resetGauges` (applies only to graphite
+backend). 
+
 Sets
 ----
 StatsD supports counting unique occurences of events between flushes,

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -35,7 +35,7 @@ Optional Variables:
     percent:        percentage of frequent keys to log [%, default: 100]
     log:            location of log file for frequent keys [default: STDOUT]
   deleteCounters:   don't send values to graphite for inactive counters, as opposed to sending 0 [default: false]
-
+  resetGauges:      reset Gauges to 0 after every flush [default: false]
   console:
     prettyprint:    whether to prettyprint the console backend
                     output [true or false, default: true]

--- a/stats.js
+++ b/stats.js
@@ -78,6 +78,13 @@ function flushMetrics() {
     for (key in metrics.sets) {
       metrics.sets[key] = new set.Set();
     }
+
+    //Reset gauges 
+    conf.resetGauges = conf.resetGauges || false;
+    for (key in metrics.gauges){
+      metrics.gauges[key] = 0;
+    }
+
   });
 
   pm.process_metrics(metrics_hash, flushInterval, time_stamp, function emitFlush(metrics) {


### PR DESCRIPTION
While its important to have gauges that retain last received values, in cases it is needed to reset the gauge value on each flush. This is a much easier way to know whether the sender has crashed.
#236    Configurable resetting of gauges to 0 on flush.

[Edit]Addresses #95 
