### PR TITLE
Readme typo - legacy key prefix is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ in the prefixing, there will also be a breaking change in the way counters are
 submitted. So far counters didn't live under any namespace and were also a bit
 confusing due to the way they record rate and absolute counts. In the legacy
 setting rates were recorded under `stats.counter_name` directly, whereas the
-absolute count could be found under `stats_count.counter_name`. With disabling
-the legacy namespacing those values can be found (with default prefixing)
+absolute count could be found under `stats_counts.counter_name`. When legacy namespacing
+is disabled those values can be found (with default prefixing)
 under `stats.counters.counter_name.rate` and
 `stats.counters.counter_name.count` now.
 


### PR DESCRIPTION
This fixes a typo in the readme where the legacy prefix was incorrectly listed as 'stats_count' instead of 'stats_counts'.
