### PR TITLE
Add support for sampling timers

### DIFF
--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -6,6 +6,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
     var statsd_metrics = {};
     var counters = metrics.counters;
     var timers = metrics.timers;
+    var timer_counters = metrics.timer_counters;
     var pctThreshold = metrics.pctThreshold;
 
     for (key in counters) {
@@ -61,11 +62,13 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         for (var i = 0; i < count; i++) {
            sumOfDiffs += (values[i] - mean) * (values[i] - mean);
         }
+
         var stddev = Math.sqrt(sumOfDiffs / count);
         current_timer_data["std"] = stddev;
         current_timer_data["upper"] = max;
         current_timer_data["lower"] = min;
-        current_timer_data["count"] = count;
+        current_timer_data["count"] = timer_counters[key];
+        current_timer_data["count_ps"] = timer_counters[key] / (flushInterval / 1000);
         current_timer_data["sum"] = sum;
         current_timer_data["mean"] = mean;
 

--- a/test/process_metrics_tests.js
+++ b/test/process_metrics_tests.js
@@ -7,6 +7,7 @@ module.exports = {
     var counters = {};
     var gauges = {};
     var timers = {};
+    var timer_counters = {};
     var sets = {};
     var pctThreshold = null;
 
@@ -14,6 +15,7 @@ module.exports = {
       counters: counters,
       gauges: gauges,
       timers: timers,
+      timer_counters: timer_counters,
       sets: sets,
       pctThreshold: pctThreshold
     }
@@ -36,33 +38,38 @@ module.exports = {
   timers_handle_empty: function(test) {
     test.expect(1);
     this.metrics.timers['a'] = [];
+    this.metrics.timer_counters['a'] = 0;
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
     //potentially a cleaner way to check this
     test.equal(undefined, this.metrics.counter_rates['a']);
     test.done();
   },
   timers_single_time: function(test) {
-    test.expect(6);
+    test.expect(7);
     this.metrics.timers['a'] = [100];
+    this.metrics.timer_counters['a'] = 1;
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(0, timer_data.std);
     test.equal(100, timer_data.upper);
     test.equal(100, timer_data.lower);
     test.equal(1, timer_data.count);
+    test.equal(10, timer_data.count_ps);
     test.equal(100, timer_data.sum);
     test.equal(100, timer_data.mean);
     test.done();
   },
     timers_multiple_times: function(test) {
-    test.expect(6);
+    test.expect(7);
     this.metrics.timers['a'] = [100, 200, 300];
+    this.metrics.timer_counters['a'] = 3;
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
     test.equal(81.64965809277261, timer_data.std);
     test.equal(300, timer_data.upper);
     test.equal(100, timer_data.lower);
     test.equal(3, timer_data.count);
+    test.equal(30, timer_data.count_ps);
     test.equal(600, timer_data.sum);
     test.equal(200, timer_data.mean);
     test.done();
@@ -70,6 +77,7 @@ module.exports = {
     timers_single_time_single_percentile: function(test) {
     test.expect(3);
     this.metrics.timers['a'] = [100];
+    this.metrics.timer_counters['a'] = 1;
     this.metrics.pctThreshold = [90];
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
@@ -81,6 +89,7 @@ module.exports = {
     timers_single_time_multiple_percentiles: function(test) {
     test.expect(6);
     this.metrics.timers['a'] = [100];
+    this.metrics.timer_counters['a'] = 1;
     this.metrics.pctThreshold = [90, 80];
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
@@ -95,6 +104,7 @@ module.exports = {
     timers_multiple_times_single_percentiles: function(test) {
     test.expect(3);
     this.metrics.timers['a'] = [100, 200, 300];
+    this.metrics.timer_counters['a'] = 3;
     this.metrics.pctThreshold = [90];
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
@@ -106,9 +116,27 @@ module.exports = {
     timers_multiple_times_multiple_percentiles: function(test) {
     test.expect(6);
     this.metrics.timers['a'] = [100, 200, 300];
+    this.metrics.timer_counters['a'] = 3;
     this.metrics.pctThreshold = [90, 80];
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
     timer_data = this.metrics.timer_data['a'];
+    test.equal(200, timer_data.mean_90);
+    test.equal(300, timer_data.upper_90);
+    test.equal(600, timer_data.sum_90);
+    test.equal(150, timer_data.mean_80);
+    test.equal(200, timer_data.upper_80);
+    test.equal(300, timer_data.sum_80);
+    test.done();
+  },
+    timers_sampled_times: function(test) {
+    test.expect(8);
+    this.metrics.timers['a'] = [100, 200, 300];
+    this.metrics.timer_counters['a'] = 50;
+    this.metrics.pctThreshold = [90, 80];
+    pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
+    timer_data = this.metrics.timer_data['a'];
+    test.equal(50, timer_data.count);
+    test.equal(500, timer_data.count_ps);
     test.equal(200, timer_data.mean_90);
     test.equal(300, timer_data.upper_90);
     test.equal(600, timer_data.sum_90);


### PR DESCRIPTION
This change addresses #139

It maintains a separate counter for each timer metric counting the "true" number of events, and adds a "count_ps" (i.e. count-per-second) metric which is the equivalent of a regular counter metric (whereas timer counts have historically not been per-second; this diff maintains this behaviour for stats.timers.foo.count for backwards compatibility).
