### PR TITLE
Catch DNS errors from UDP socket in Repeater backend

### DIFF
--- a/backends/repeater.js
+++ b/backends/repeater.js
@@ -1,6 +1,8 @@
 var util = require('util'),
-    dgram = require('dgram');
-
+    dgram = require('dgram'),
+    logger = require('../lib/logger');
+var l;
+var debug;
 function RepeaterBackend(startupTime, config, emitter){
   var self = this;
   this.config = config.repeater || [];
@@ -9,7 +11,9 @@ function RepeaterBackend(startupTime, config, emitter){
         dgram.createSocket('udp4');
   // Attach DNS error handler
   this.sock.on('error', function (err) {
-    console.log('Repeater error: ' + err);
+    if (debug) {
+      l.log('Repeater error: ' + err);
+    }
   });
   // attach
   emitter.on('packet', function(packet, rinfo) { self.process(packet, rinfo); });
@@ -21,8 +25,8 @@ RepeaterBackend.prototype.process = function(packet, rinfo) {
   for(var i=0; i<hosts.length; i++) {
     self.sock.send(packet,0,packet.length,hosts[i].port,hosts[i].host,
                    function(err,bytes) {
-      if (err) {
-        console.log(err);
+      if (err && debug) {
+        l.log(err);
       }
     });
   }
@@ -30,5 +34,7 @@ RepeaterBackend.prototype.process = function(packet, rinfo) {
 
 exports.init = function(startupTime, config, events) {
   var instance = new RepeaterBackend(startupTime, config, events);
+  l = new logger.Logger(config.log || {});
+  debug = config.debug;
   return true;
 };


### PR DESCRIPTION
If repeater is used with hostnames rather than IPs
a DNS resolution error crashes statsd server.
If you have a chain of statsd servers configured
to repeat data down the line this has the potential
to bring down the entire chain.

Attaching an error handler stops dgram socket from
throwing an exception and instead logs to console
