### PR TITLE
Delete folder of metrics with: delcounters parent.path.*

### DIFF
--- a/lib/mgmt_console.js
+++ b/lib/mgmt_console.js
@@ -1,0 +1,68 @@
+
+/**
+ * delete_stats - delete all matching statistics
+ * 
+ * Side effect notes: this function works by altering stats_type in place,
+ *   and calls stream.write(str) to display user feedback.
+ * 
+ * @param stats_type array of all statistics of this type (eg~ timers) to delete from
+ * @param cmdline array of all requested deletions, which can be fully qualified,
+ *   or end in a .* to delete a folder, like stats.temp.*
+ * @param stream buffer output for for all outgoing user feedback
+ */
+exports.delete_stats = function(stats_type, cmdline, stream) {
+
+  //for each metric requested on the command line
+  for (var index in cmdline) {
+    
+    //get a list of deletable metrics that match the request
+    deletable = existing_stats(stats_type, cmdline[index]);
+    
+    //warn if no matches
+    if (deletable.length == 0) {
+      stream.write("metric " + cmdline[index] + " not found\n");
+    }
+    
+    //delete all requested metrics
+    for (var del_idx in deletable) {
+      delete stats_type[deletable[del_idx]];
+      stream.write("deleted: " + deletable[del_idx] + "\n");
+    }
+  }
+  stream.write("END\n\n");
+}
+
+/**
+ * existing_stats - find fully qualified matches for the requested stats bucket
+ * 
+ * @param stats_type array of all statistics of this type (eg~ timers) to match
+ * @param bucket string to search on, which can be fully qualified,
+ *   or end in a .* to search for a folder, like stats.temp.*
+ * 
+ * @return array of fully qualified stats that match the specified bucket. if
+ *   no matches, an empty array is a valid response
+ */
+function existing_stats(stats_type, bucket){
+  matches = []
+
+  //typical case: one-off, fully qualified
+  if (bucket in stats_type) {
+    matches.push(bucket);
+  }
+
+  //special case: match a whole 'folder' (and subfolders) of stats
+  if (bucket.slice(-2) == ".*") {
+    var folder = bucket.slice(0,-1);
+    
+    for (var name in stats_type) {
+      //check if stat is in bucket, ie~ name starts with folder
+      if (name.substring(0, folder.length) == folder) {
+        matches.push(name);
+      }
+    }
+  }
+  
+  return matches;
+}
+
+exports.existing_stats = existing_stats;

--- a/test/mgmt_console_tests.js
+++ b/test/mgmt_console_tests.js
@@ -1,0 +1,65 @@
+var mgmt = require('../lib/mgmt_console');
+
+module.exports = {
+  stat_matches: function(test) {
+    test.expect(8);
+    stat_vertical = {'a.b':1,'a.c':1,'c':1};
+    
+    //test function
+    f = function (bucket) { return mgmt.existing_stats(stat_vertical, bucket) }
+
+    //empties
+    test.deepEqual(f('d'), []);
+    test.deepEqual(f('a'), []);
+    test.deepEqual(f('c.a'), []);
+    test.deepEqual(f('c.*'), []);
+    test.deepEqual(f(''), []);
+    
+    //single matches
+    test.deepEqual(f('a.b'), ['a.b']);
+    test.deepEqual(f('c'), ['c']);
+    
+    //multiple matches
+    test.deepEqual(f('a.*'), ['a.b', 'a.c']);
+    
+    test.done();
+  },
+  
+  stat_deletes: function(test) {
+    test.expect(6);
+    
+    var stream = {
+        buffer : '',
+        clear : function() { this.buffer = '' },
+        write : function(to_write) { this.buffer += to_write },
+        };
+    
+    stats_fixture = 
+    
+    //delete missing
+    stat_vertical = {'a.b':1,'a.c':1,'d':1};
+    stream.clear();
+    mgmt.delete_stats(stat_vertical, ['e'], stream);
+    
+    test.deepEqual(stat_vertical, stats_fixture);
+    test.equal(stream.buffer, 'metric e not found\nEND\n\n');
+    
+    //delete fully qualified
+    stat_vertical = {'a.b':1,'a.c':1,'d':1};
+    stream.clear();
+    mgmt.delete_stats(stat_vertical, ['a.b'], stream);
+    
+    test.deepEqual(stat_vertical, {'a.c':1,'d':1});
+    test.equal(stream.buffer, 'deleted: a.b\nEND\n\n');
+    
+    //delete folder
+    stat_vertical = {'a.b':1,'a.c':1,'d':1};
+    stream.clear();
+    mgmt.delete_stats(stat_vertical, ['a.*'], stream);
+    
+    test.deepEqual(stat_vertical, {'d':1});
+    test.equal(stream.buffer, 'deleted: a.b\ndeleted: a.c\nEND\n\n');
+    
+    test.done();
+  },
+}


### PR DESCRIPTION
Sorry this doesn't include tests. I manually confirmed that this works on counters, gauges, and timers.

Some Bonuses:
- A minor refactor of the delete code in the management server. The five repeated lines for every delete command are now one.
- The management server now warns you when you try to delete something, but it wasn't there yet.

I didn't add anything more complex like regex, because I didn't like the idea of having to escape the dots when issuing commands. This seems simple and to cover a lot of cases.
