### PR TITLE
Remove debugInterval in favor of console backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ Debugging
 
 There are additional config variables available for debugging:
 
-* `debug` - log exceptions and periodically print out information on counters and timers
-* `debugInterval` - interval for printing out information on counters and timers
+* `debug` - log exceptions and print out more diagnostic info
 * `dumpMessages` - print debug info on incoming messages
 
 For more information, check the `exampleConfig.js`.
@@ -161,7 +160,7 @@ StatsD includes the following built-in backends:
 * [Graphite][graphite] (`graphite`): An open-source
   time-series data store that provides visualization through a web-browser.
 * Console (`console`): Outputs the received
-  metrics to stdout (see what's going on during development).
+  metrics to stdout (see what's going on during development or debugging).
 * Repeater (`repeater`): Utilizes the `packet` emit API to
   forward raw packets retrieved by StatsD to multiple backend StatsD instances.
 

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -24,7 +24,6 @@ Optional Variables:
   mgmt_address:     address to run the management TCP interface on
                     [default: 0.0.0.0]
   mgmt_port:        port to run the management TCP interface on [default: 8126]
-  debugInterval:    interval to print debug information [ms, default: 10000]
   dumpMessages:     log all incoming messages
   flushInterval:    interval (in ms) to flush to Graphite
   percentThreshold: for time information, calculate the Nth percentile(s)

--- a/stats.js
+++ b/stats.js
@@ -19,7 +19,7 @@ var sets = {};
 var counter_rates = {};
 var timer_data = {};
 var pctThreshold = null;
-var debugInt, flushInterval, keyFlushInt, server, mgmtServer;
+var flushInterval, keyFlushInt, server, mgmtServer;
 var startup_time = Math.round(new Date().getTime() / 1000);
 var backendEvents = new events.EventEmitter();
 
@@ -103,34 +103,17 @@ var l;
 
 config.configFile(process.argv[2], function (config, oldConfig) {
   conf = config;
-  if (! config.debug && debugInt) {
-    clearInterval(debugInt);
-    debugInt = false;
-  }
-
   l = new logger.Logger(config.log || {});
 
-  if (config.debug) {
-    if (debugInt !== undefined) {
-      clearInterval(debugInt);
-    }
-    debugInt = setInterval(function () {
-      l.log("\nCounters:\n" + util.inspect(counters) +
-               "\nTimers:\n" + util.inspect(timers) +
-               "\nSets:\n" + util.inspect(sets) +
-               "\nGauges:\n" + util.inspect(gauges), 'DEBUG');
-    }, config.debugInterval || 10000);
-  }
-
   // setup config for stats prefix
-  prefixStats       = config.prefixStats;
-  prefixStats     = prefixStats !== undefined ? prefixStats : "statsd";
+  prefixStats = config.prefixStats;
+  prefixStats = prefixStats !== undefined ? prefixStats : "statsd";
   //setup the names for the stats stored in counters{}
-  bad_lines_seen = prefixStats + ".bad_lines_seen";
+  bad_lines_seen   = prefixStats + ".bad_lines_seen";
   packets_received = prefixStats + ".packets_received";
 
   //now set to zero so we can increment them
-  counters[bad_lines_seen] = 0;
+  counters[bad_lines_seen]   = 0;
   counters[packets_received] = 0;
 
   if (server === undefined) {


### PR DESCRIPTION
I propose that we remove the debug interval functionality and guide people towards the console backend for this data.

The debug interval is a different interval than the flush interval and can cause confusing results.
