### PR TITLE
Add configuration option to listen on an IPv6 address

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,20 @@ under `stats.counters.counter_name.rate` and
 The number of elements in sets will be recorded under the metric
 `stats.sets.set_name.count` (where "sets" is the prefixSet).
 
+IPv6
+----
+
+Here's an example on how to configure the UDP listener to listen on an IPv6 address:
+
+```
+{
+, address: "::1"
+, address_ipv6: true
+}
+```
+
+By default, if the `address_ipv6` configuration option is not set (or set to `false`), the socket will use IPv4.
+
 Inspiration
 -----------
 

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -20,6 +20,7 @@ Optional Variables:
                     the default graphite backend will be loaded.
   debug:            debug flag [default: false]
   address:          address to listen on over UDP [default: 0.0.0.0]
+  address_ipv6:     defines if the address is an IPv4 or IPv6 address [true or false, default: false]
   port:             port to listen for messages on over UDP [default: 8125]
   mgmt_address:     address to run the management TCP interface on
                     [default: 0.0.0.0]

--- a/stats.js
+++ b/stats.js
@@ -121,7 +121,8 @@ config.configFile(process.argv[2], function (config, oldConfig) {
     // key counting
     var keyFlushInterval = Number((config.keyFlush && config.keyFlush.interval) || 0);
 
-    server = dgram.createSocket('udp4', function (msg, rinfo) {
+    var udp_version = config.address_ipv6 ? 'udp6' : 'udp4'
+    server = dgram.createSocket(udp_version, function (msg, rinfo) {
       backendEvents.emit('packet', msg, rinfo);
       counters[packets_received]++;
       var packet_data = msg.toString();


### PR DESCRIPTION
The UDP listener will bind to an IPv6 address if the `address_ipv6` configuration option is set to `true`. :sparkles: Otherwise it defaults to IPv4 (`udp4`).
