### PR TITLE
Remove caching from the console backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 node_modules
-
-config.js
-


### PR DESCRIPTION
The caching behavior is extremely confusing for a new user. Statsd -> Graphite has enough gotchas around metric retention as it is - no need for the console backend to output different values per flush to the console than it would to Graphite.

I realize there's an open pull request to add an option. Instead, I'd like to argue that any caching backend become a specialized backend, and that the simple case be the standard console backend with no caching.

Thank you for reviewing!
Brian
