### PR TITLE
Statsd -> Graphite backend via HTTP Post

### DIFF
--- a/backends/graphite-http.js
+++ b/backends/graphite-http.js
@@ -1,15 +1,15 @@
 /*
  * Flush stats to graphite (http://graphite.wikidot.com/).
  *
- * To enable this backend, include 'graphite' in the backends
+ * To enable this backend, include 'graphite-http' in the backends
  * configuration array:
  *
- *   backends: ['graphite']
+ *   backends: ['graphite-http']
  *
  * This backend supports the following config options:
  *
- *   graphiteHost: Hostname of graphite server.
- *   graphitePort: Port to contact graphite server at.
+ *   bridgeURL: URL of the HTTP bridge, with trailing slash.
+ *   api_key: API key, appended to URL.
  */
 
 var net = require('net'),


### PR DESCRIPTION
This is a modified version of the statsd graphite backend that sends batches of metrics via HTTP post (one per flush) in JSON format. Supports a similar format to Backstop, where 'api_key' would be a Backstop 'prefix'.

This is also usable with https://github.com/bmhatfield/graphite-http-bridge.
