### PR TITLE
Add source IP filtering

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.6.1 (04/30/2013)
+- added possibility to filter incomming datagrams by source IP address
+
 ## v0.6.0 (03/15/2013)
 - added new metric types : sets, gauge deltas, histograms
 - added ability to delete idle stats

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ More Specific Topics
 * [Admin TCP Interface][docs_admin_interface]
 * [Backend Interface][docs_backend_interface]
 * [Metric Namespacing][docs_namespacing]
+* [Security][docs_security]
 
 
 Debugging

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,42 @@
+# Security
+
+Although **statsd** would be preferably configured to listen for UDP datagrams
+on local IP address (*loopback*), it is sometime usefull to bind listening
+socket to *any* address in order to be able to receive metrics sent from
+other machine. In this case, there might be a possible security issue allowing
+some unwanted client to send metrics to statsd (altering regular metrics or
+flooding the system).
+
+One could setup firewall rules (*iptables*, *firewalld*, ...) to solve this
+problem, but it is also possible to add some basic filtering rules inside
+**statsd** to discard unwanted client by specifying some *blacklisted* IP
+sources.
+
+### Configuration
+
+The available configuration options (living under the *fromOnly* key) are:
+
+    family:     restrict by IP family ['ipv4' or 'ipv6', default: undefined]
+    addresses:  array of allowed client IP addresses or range (with .../bits syntax) [default: undefined]
+
+* The `config.fromOnly.family` can be used to allow only clients of a given IP
+  family address. the *ipv4* and *ipv6* keywords are supported. Do not specify
+  this parameter if you do not want to filter based on family types.
+* The `config.fromOnly.adresses` can be used to restrict client machines by
+  their IP adress. You can specify and array of strings representing those
+  adresses. An address is either a plain address (ipv4 or ipv6) or a subnet by
+  suffixing the adress with */bits* representing the number of bits of the mask.
+  If this parameter in not specified, then no filtering is done based on source
+  IP address.
+  
+#### Example:
+
+    onlyFrom : {
+      family : "ipv4",
+      addresses : [ "127.0.0.1", "192.168.0.0/16" ]
+    }
+
+---
+
+_Note_: If a datagram matches the specified filtering rule, it is silently dropped and even no log record is generated (in case of flooding attack).
+

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -22,6 +22,9 @@ Optional Variables:
   address:          address to listen on over UDP [default: 0.0.0.0]
   address_ipv6:     defines if the address is an IPv4 or IPv6 address [true or false, default: false]
   port:             port to listen for messages on over UDP [default: 8125]
+  fromOnly:         restrict allowed client by their IP source address [object, default: undefined]
+    family:         restrict by IP family ['ipv4' or 'ipv6', default: undefined]
+    addresses:      array of allowed client IP addresses or range (with .../bits syntax) [default: undefined]
   mgmt_address:     address to run the management TCP interface on
                     [default: 0.0.0.0]
   mgmt_port:        port to run the management TCP interface on [default: 8126]

--- a/lib/ipfilter.js
+++ b/lib/ipfilter.js
@@ -1,0 +1,91 @@
+/*
+** Module: ipfilter
+**
+ */
+ 
+var ipaddr = require('ipaddr.js');
+
+var IpFilter = function (config) {
+	this.self = this;
+	this.active = false;
+	this.addrs = [];
+	if (config && config.onlyFrom) {
+		this.family = config.onlyFrom.family;
+		if (this.family) {
+			this.active = true;
+		}
+		if (config.onlyFrom.addresses) {
+		    var addresses 
+			if (typeof config.onlyFrom.addresses === "string") {
+				addresses = [config.onlyFrom.addresses];
+			} else  {
+				addresses = config.onlyFrom.addresses;
+			}
+			
+        	for (var i = 0; i < addresses.length; i++) {
+            	var confAddrStr = addresses[i];
+            	var parts = confAddrStr.match(/^([^\/]+)\/(\d+)$/);
+            	var size, addr;
+            	if (parts && parts.length === 3) {
+                	// Address is a range ".../bits"
+                	addr = ipaddr.parse(parts[1]);
+                	size = Number(parts[2]);
+            	} else {
+                	addr = ipaddr.parse(confAddrStr);
+                	size = (addr.kind() === 'ipv6' ? 128 : 32);
+            	}
+				this.addrs.push({
+					'addr' : addr,
+					'kind' : addr.kind(),
+					'size' : size
+					});
+			    this.active = true;
+        	}
+        }
+    }
+};
+
+IpFilter.prototype.check_allowed = function (rinfo) {
+    if (! this.active) {
+	    // No filtering -> Allow
+		return true;
+	}
+	
+	// Check rinfo parameter
+    if (! rinfo || ! rinfo.address || ! ipaddr.isValid(rinfo.address) ||
+		! rinfo.family || typeof rinfo.family !== 'string') {
+	    // No 'received from' address or family ! -> Deny
+        return false;
+    }
+    
+    // Filter based on IP family
+    if (this.family && this.family.toLowerCase() !== rinfo.family.toLowerCase()) {
+        //console.log('Not allowed IP family: ' + rinfo.family);
+        return false;
+    }
+    
+    
+    //Filter based on IP address
+    if (this.addrs.length) {
+    	var inAddr = ipaddr.parse(rinfo.address);
+    	var allowed = false;
+    
+        for (var i = 0; i < this.addrs.length; i++) {
+            
+            if (inAddr.kind() === this.addrs[i].kind &&
+                inAddr.match(this.addrs[i].addr, this.addrs[i].size)) {
+                allowed = true;
+                break;
+            }     
+        }
+        if (! allowed) {
+            //console.log('Not allowed IP adress: ' + rinfo.family);
+            return false;
+        }
+    }
+    return true;
+};
+
+exports.IpFilter = IpFilter;
+
+

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "type": "git",
     "url": "https://github.com/etsy/statsd.git"
   },
-  "version": "0.6.0",
+  "version": "0.6.1",
   "dependencies": {
+    "ipaddr.js": "~0.1.1"
   },
   "devDependencies": {
     "nodeunit": "0.7.x",
@@ -21,11 +22,13 @@
     "temp": "0.4.x"
   },
   "optionalDependencies": {
-    "node-syslog":"1.1.7",
+    "node-syslog": "1.1.7",
     "winser": "=0.0.11"
   },
   "engines": {
-    "node" : ">=0.6"
+    "node": ">=0.6"
   },
-  "bin": { "statsd": "./bin/statsd" }
+  "bin": {
+    "statsd": "./bin/statsd"
+  }
 }

--- a/test/ipfilter_tests.js
+++ b/test/ipfilter_tests.js
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for ipfilter module
+ */
+
+
+var ipfilter = require('../lib/ipfilter');
+
+
+module.exports = {
+	no_config_allow_all: function(test) {
+    	test.expect(16);
+    	var filter = new ipfilter.IpFilter(null);
+    	
+    	// Allow all (even invalid rinfo)
+        test.equal(filter.check_allowed(), true, "No rinfo");
+        test.equal(filter.check_allowed(null), true, "Null rinfo");
+        test.equal(filter.check_allowed( {} ), true, "Empty rinfo");
+        test.equal(filter.check_allowed( {address: ""} ), true, "Empty address rinfo");
+        test.equal(filter.check_allowed( {address: "123.4"} ), true, "Bad address rinfo");  
+        test.equal(filter.check_allowed( {address: "127.0.0.1"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:""} ), true, "Epmty family rinfo"); 
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:4} ), true, "Bad family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:"IPv4"} ), true, "Good loopback rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0", family:"IPv4"} ), true, "Good any rinfo");
+        test.equal(filter.check_allowed( {address:"1.2.3.4"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"::1", family:"IPv6"} ), true, "Good loopback ipv6  rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4", family:"IPv6"} ), true, "Good ipv6 rinfo");
+        test.equal(filter.check_allowed( {address:"::ffff:192.168.1.1", family:"IPv6"} ), true, "Good ipv6 rinfo");
+    	
+    	test.done();
+  	},
+  	empty_config_allow_all: function(test) {
+    	test.expect(16);
+    	var filter = new ipfilter.IpFilter( { onlyFrom: { } } );
+    	
+    	// Allow all (even invalid rinfo) same as above
+        test.equal(filter.check_allowed(), true, "No rinfo");
+        test.equal(filter.check_allowed(null), true, "Null rinfo");
+        test.equal(filter.check_allowed( {} ), true, "Empty rinfo");
+        test.equal(filter.check_allowed( {address: ""} ), true, "Empty address rinfo");
+        test.equal(filter.check_allowed( {address: "123.4"} ), true, "Bad address rinfo");  
+        test.equal(filter.check_allowed( {address: "127.0.0.1"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:""} ), true, "Epmty family rinfo"); 
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:4} ), true, "Bad family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:"IPv4"} ), true, "Good loopback rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0", family:"IPv4"} ), true, "Good any rinfo");
+        test.equal(filter.check_allowed( {address:"1.2.3.4"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"::1", family:"IPv6"} ), true, "Good loopback ipv6  rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4", family:"IPv6"} ), true, "Good ipv6 rinfo");
+        test.equal(filter.check_allowed( {address:"::ffff:192.168.1.1", family:"IPv6"} ), true, "Good ipv6 rinfo");
+    	test.done();
+    },
+    conf_ipv4_only: function(test) {
+    	test.expect(16);
+    	var filter = new ipfilter.IpFilter( {
+				onlyFrom : {
+					family : "IpV4"
+				} 
+			} );
+    	
+    	// Deny invalid rinfo
+        test.equal(filter.check_allowed(), false, "No rinfo");
+        test.equal(filter.check_allowed(null), false, "Null rinfo");
+        test.equal(filter.check_allowed( {} ), false, "Empty rinfo");
+        test.equal(filter.check_allowed( {address: ""} ), false, "Empty address rinfo");
+        test.equal(filter.check_allowed( {address: "123.4"} ), false, "Bad address rinfo");  
+        test.equal(filter.check_allowed( {address: "127.0.0.1"} ), false, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:""} ), false, "Empty family rinfo"); 
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:4} ), false, "Badfamily rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0"} ), false, "Empty family rinfo");
+        test.equal(filter.check_allowed( {address:"1.2.3.4"} ), false, "Empty family rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4"} ), false, "No family rinfo");
+        
+        
+        // Allow valid ipv4 addresses
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:"IPv4"} ), true, "Good loopback rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0", family:"IPv4"} ), true, "Good any rinfo");
+        test.equal(filter.check_allowed( {address:"1.2.3.4", family:"IPv4"} ), true, "Good ipv4 rinfo");
+       
+        // Deny ipv6 addresses
+        test.equal(filter.check_allowed( {address:"::1", family:"IPv6"} ), false, "Good loopback ipv6 rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4", family:"IPv6"} ), false, "Good ipv6 rinfo");
+        
+        test.done();
+    },
+    conf_empty_addresses_allow_all: function(test) {
+    	test.expect(16);
+    	var filter = new ipfilter.IpFilter( {
+				onlyFrom : {
+					addresses : []
+				} 
+			} );
+			
+		// Allow all (even invalid rinfo)
+        test.equal(filter.check_allowed(), true, "No rinfo");
+        test.equal(filter.check_allowed(null), true, "Null rinfo");
+        test.equal(filter.check_allowed( {} ), true, "Empty rinfo");
+        test.equal(filter.check_allowed( {address: ""} ), true, "Empty address rinfo");
+        test.equal(filter.check_allowed( {address: "123.4"} ), true, "Bad address rinfo");  
+        test.equal(filter.check_allowed( {address: "127.0.0.1"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:""} ), true, "Epmty family rinfo"); 
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:4} ), true, "Bad family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:"IPv4"} ), true, "Good loopback rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0", family:"IPv4"} ), true, "Good any rinfo");
+        test.equal(filter.check_allowed( {address:"1.2.3.4"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"::1", family:"IPv6"} ), true, "Good loopback ipv6  rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4"} ), true, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4", family:"IPv6"} ), true, "Good ipv6 rinfo");
+        test.equal(filter.check_allowed( {address:"::ffff:192.168.1.1", family:"IPv6"} ), true, "Good ipv6 rinfo");
+    	
+    	test.done();
+    },
+    conf_1_address: function(test) {
+    	test.expect(18);
+    	var filter = new ipfilter.IpFilter( {
+				onlyFrom : {
+					addresses : "1.2.3.4",
+				}
+			} );
+			
+		// Deny invalid rinfo
+        test.equal(filter.check_allowed(), false, "No rinfo");
+        test.equal(filter.check_allowed(null), false, "Null rinfo");
+        test.equal(filter.check_allowed( {} ), false, "Empty rinfo");
+        test.equal(filter.check_allowed( {address: ""} ), false, "Empty address rinfo");
+        test.equal(filter.check_allowed( {address: "123.4"} ), false, "Bad address rinfo");  
+        test.equal(filter.check_allowed( {address: "127.0.0.1"} ), false, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:""} ), false, "Empty family rinfo"); 
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:4} ), false, "Badfamily rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0"} ), false, "Empty family rinfo");
+        test.equal(filter.check_allowed( {address:"1.2.3.4"} ), false, "Empty family rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4"} ), false, "No family rinfo");
+        
+    	
+    	// Allow one the specified address
+		test.equal(filter.check_allowed( {address: "1.2.3.4", family:"IPv4"} ), true, "Good matching ipv4 rinfo");
+        
+        // Deny not specified address
+        test.equal(filter.check_allowed( {address:"4.3.2.1", family:"IPv4"} ), false, "Non matching ipv4 rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:"IPv4"} ), false, "Non matching loopback rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0", family:"IPv4"} ), false, "Non matching any rinfo");
+        test.equal(filter.check_allowed( {address:"::1", family:"IPv6"} ), false, "Non matching loopback ipv6 rinfo");
+        test.equal(filter.check_allowed( {address:"::ffff:192.168.1.1", family:"IPv6"} ), false, "Non matching ipv6 rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4", family:"IPv6"} ), false, "Non matching ipv6 rinfo");
+        
+		test.done();
+    },
+    conf_2_addresses: function(test) {
+    	test.expect(19);
+    	var filter = new ipfilter.IpFilter( {
+				onlyFrom : {
+					addresses : ["1.2.3.4", "5.6.7.8"]
+				}
+			} );
+			
+        // Deny invalid rinfo
+        test.equal(filter.check_allowed(), false, "No rinfo");
+        test.equal(filter.check_allowed(null), false, "Null rinfo");
+        test.equal(filter.check_allowed( {} ), false, "Empty rinfo");
+        test.equal(filter.check_allowed( {address: ""} ), false, "Empty address rinfo");
+        test.equal(filter.check_allowed( {address: "123.4"} ), false, "Bad address rinfo");  
+        test.equal(filter.check_allowed( {address: "127.0.0.1"} ), false, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:""} ), false, "Empty family rinfo"); 
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:4} ), false, "Badfamily rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0"} ), false, "Empty family rinfo");
+        test.equal(filter.check_allowed( {address:"1.2.3.4"} ), false, "Empty family rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4"} ), false, "No family rinfo");
+        
+    	
+    	// Allow one the specified address
+		test.equal(filter.check_allowed( {address: "1.2.3.4", family:"IPv4"} ), true, "Good matching ipv4 rinfo");
+        test.equal(filter.check_allowed( {address: "5.6.7.8", family:"IPv4"} ), true, "Good matching ipv4 rinfo");
+        
+        // Deny not specified address
+        test.equal(filter.check_allowed( {address:"4.3.2.1", family:"IPv4"} ), false, "Non matching ipv4 rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:"IPv4"} ), false, "Non matching loopback rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0", family:"IPv4"} ), false, "Non matching any rinfo");
+        test.equal(filter.check_allowed( {address:"::1", family:"IPv6"} ), false, "Non matching loopback ipv6 rinfo");
+        test.equal(filter.check_allowed( {address:"::ffff:192.168.1.1", family:"IPv6"} ), false, "Non matching ipv6 rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4", family:"IPv6"} ), false, "Non matching ipv6 rinfo");
+        
+		test.done();
+    },
+    conf_with_ipv4_range: function(test) {
+    	test.expect(16);
+    	var filter = new ipfilter.IpFilter( {
+				onlyFrom : {
+					addresses : ["1.2.0.0/16", "5.6.7.8"]
+				}
+			} );
+			
+		// Deny invalid rinfo
+    	test.equal(filter.check_allowed(), false, "No rinfo");
+        test.equal(filter.check_allowed(null), false, "Null rinfo");
+        test.equal(filter.check_allowed( {} ), false, "Empty rinfo");
+        test.equal(filter.check_allowed( {address: ""} ), false, "Empty address rinfo");
+        test.equal(filter.check_allowed( {address: "123.4"} ), false, "Bad address rinfo");  
+        test.equal(filter.check_allowed( {address: "127.0.0.1"} ), false, "No family rinfo");
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:""} ), false, "Empty family rinfo"); 
+        test.equal(filter.check_allowed( {address:"127.0.0.1", family:4} ), false, "Badfamily rinfo");
+        test.equal(filter.check_allowed( {address:"0.0.0.0"} ), false, "Empty family rinfo");
+        test.equal(filter.check_allowed( {address:"1.2.3.4"} ), false, "Empty family rinfo");
+        test.equal(filter.check_allowed( {address:"2607:f0d0:1002:51::4"} ), false, "No family rinfo");
+        
+        // Allow one of specfied address
+		test.equal(filter.check_allowed( {address: "5.6.7.8", family:"IPv4"} ), true, "Good matching ipv4 rinfo");
+		
+		// Allow any address in range
+		test.equal(filter.check_allowed( {address: "1.2.0.0", family:"IPv4"} ), true, "Good matching ipv4 range rinfo");
+		test.equal(filter.check_allowed( {address: "1.2.3.4", family:"IPv4"} ), true, "Good matching ipv4 range rinfo");
+		
+		// Deny adressses out of range
+		test.equal(filter.check_allowed( {address:"1.3.0.0", family:"IPv4"} ), false, "Out of range ipv4 rinfo");
+		test.equal(filter.check_allowed( {address:"4.3.2.1", family:"IPv4"} ), false, "Out of range ipv4 rinfo");
+		
+		test.done();
+	}
+};
+
+
+ 


### PR DESCRIPTION
Here is a small addon that is able to exclude some incoming packets based on their source IP address of family.

This feature allow to select the client machine that are allowed to send metrics to statsd.

See the docs/security.md for documentation.
Also added unit tests for this new feature.

Regards.

Eric Blanchard