### PR TITLE
fixed default retention suggestion

### DIFF
--- a/docs/graphite.md
+++ b/docs/graphite.md
@@ -15,12 +15,12 @@ To define retention and downsampling which match your needs, edit Graphite's con
 
     [stats]
     pattern = ^stats.*
-    retentions = 10s:6h,1min:7d,10min:5y
+    retentions = 10s:6h,1min:6d,10min:1800d
 
 This translates to: for all metrics starting with 'stats' (i.e. all metrics sent by statsd), capture:
 
 * 6 hours of 10 second data (what we consider "near-realtime")
-* 1 week of 1 minute data
+* 6 days of 1 minute data
 * 5 years of 10 minute data
 
 These settings have been a good tradeoff so far between size-of-file (database files are fixed size) and data we care about. Each "stats" database file is about 3.2 megs with these retentions.


### PR DESCRIPTION
the previous settings creates an aggregation problem because of http://graphite.readthedocs.org/en/0.9.10/whisper.html#archives-retention-and-precision

each metric bucket size needs to divide evenly into the next resolution up.  the first bucket (10s:6h) is 2160 elements, so either 1min:6d needs to be the next bucket, and 10min:1800d the following, or the first bucket needs to be changed to 10s:252m.

I left the text description at '5 years' because 1800 days is 4.93 years...
