### PR TITLE
Composition Engine

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -87,6 +87,28 @@ Optional Variables:
                      [ { metric: 'foo', bins: [] },
                        { metric: '', bins: [ 50, 100, 150, 200, 'inf'] } ]
 
+  compositions:     rules to use while composing counters metrics.
+    source:         path for the rules file. should comply to the following structure:
+                      module.exports = [{
+                          name: "#0.ctr.#1", // output metric. sharps are back references for following regexp
+                          regexp: [
+                              /^([a-z]+)\.click\.([a-z]+)/, // click metric regex
+                              /^([a-z]+)\.view\.([a-z]+)/ // view metric regex
+                          ],
+                          compose: function(click, view) { // composing function
+                              return 100 * (click / view);
+                          }
+                      },{
+                          name: "#0.res_time.#1",
+                          regexp: [
+                              /^([a-z]+)\.time\.([a-z]+)/,
+                              /^([a-z]+)\.count\.([a-z]+)/
+                          ],
+                          compose: function(time, count) {
+                              return time / count;
+                          }
+                      }}];
+
 */
 {
   graphitePort: 2003

--- a/lib/composition_engine.js
+++ b/lib/composition_engine.js
@@ -1,0 +1,42 @@
+module.exports = function(compositions, sourceMetrics, callback) {
+    Object.keys(sourceMetrics.counters).forEach(function(key){
+        compositions.forEach(function(composition) {
+            composition.regexp.forEach(function(metric, index) {
+                var matches = key.match(metric),
+                    metricName = composition.name;
+
+                if (!composition["metrics"]) {
+                    composition.metrics = {};
+                }
+
+                if (matches) {
+                    matches.slice(1, matches.length).forEach(function(m, index){
+                        metricName = metricName.replace("#" + index, m);
+                    });
+
+                    if(!composition.metrics[metricName]) {
+                        composition.metrics[metricName] = [];
+                    }
+
+                    composition.metrics[metricName][index] = sourceMetrics.counters[key];
+                }
+            });
+        });
+    });
+
+    compositions.forEach(function(composition){
+        Object.keys(composition.metrics).forEach(function(metric){
+            var result = composition.compose.apply(composition.compose, composition.metrics[metric]);
+
+            if (Number.isNaN(result)) {
+                return;
+            }
+
+            sourceMetrics.counters[metric] = result;
+        });
+
+        composition.metrics = {};
+    });
+
+    callback(sourceMetrics);
+};

--- a/stats.js
+++ b/stats.js
@@ -120,7 +120,13 @@ function flushMetrics() {
   });
 
   pm.process_metrics(metrics_hash, flushInterval, time_stamp, function emitFlush(metrics) {
-    backendEvents.emit('flush', time_stamp, metrics);
+    if (conf.composition) {
+      require(conf.composition)(metrics, function(m) {
+        backendEvents.emit('flush', time_stamp, m);
+      });
+    } else {
+      backendEvents.emit('flush', time_stamp, metrics);
+    }
   });
 
 }

--- a/stats.js
+++ b/stats.js
@@ -9,7 +9,8 @@ var dgram  = require('dgram')
   , logger = require('./lib/logger')
   , set = require('./lib/set')
   , pm = require('./lib/process_metrics')
-  , mgmt = require('./lib/mgmt_console');
+  , mgmt = require('./lib/mgmt_console')
+  , ce = require('./lib/composition_engine');
 
 
 // initialize data structures with defaults for statsd stats
@@ -120,8 +121,10 @@ function flushMetrics() {
   });
 
   pm.process_metrics(metrics_hash, flushInterval, time_stamp, function emitFlush(metrics) {
-    if (conf.composition) {
-      require(conf.composition)(metrics, function(m) {
+    if (conf.compositions && conf.compositions.source) {
+
+      var compositions = require(conf.compositions.source);
+      ce(compositions, metrics, function(m) {
         backendEvents.emit('flush', time_stamp, m);
       });
     } else {

--- a/test/composition_engine_tests.js
+++ b/test/composition_engine_tests.js
@@ -1,0 +1,43 @@
+var ce = require('../lib/composition_engine');
+
+module.exports = {
+  setUp: function (callback) {
+
+    var counters = {};
+
+    this.metrics = {
+      counters: counters
+    }
+
+    this.compositions = [{
+      name: "#0.res_time.#1",
+      regexp:[
+        /^([a-z]+)\.time\.([a-z]+)/,
+        /^([a-z]+)\.count\.([a-z]+)/
+      ],
+      compose: function(time, count) {
+        return time / count;
+      }
+    }];
+
+    callback();
+  },
+  calculate_response_time: function(test) {
+    test.expect(1);
+    this.metrics.counters['site.time.page'] = 100;
+    this.metrics.counters['site.count.page'] = 2;
+    ce(this.compositions, this.metrics, function(metrics){
+      test.equal(50, metrics.counters['site.res_time.page']);
+    });
+    test.done();
+  },
+  should_not_store_NaN: function(test) {
+    test.expect(1);
+    this.metrics.counters['site.time.page'] = 100;
+    this.metrics.counters['site.count.page'] = undefined;
+    ce(this.compositions, this.metrics, function(metrics){
+      test.ok(!metrics.counters.hasOwnProperty['site.res_time.page']);
+    });
+    test.done();
+  }
+};


### PR DESCRIPTION
Here at Chaordic we use Librato and Graphite. Librato for several reasons. As you all know Librato can't compose metrics using functions like Graphite (ex.: Graph Data > Apply Function > Calculate > Ratio). So we built an engine to compose metrics based on existing ones. 
Metrics are sent to the composition engine before flushing it to backends. Compositions are calculate based on rules defined at a source file. For example: 

Rule:
```javascript
{
      name: "#0.ctr.#1",
      regexp:[
        /^([a-z]+)\.click\.([a-z]+)/,
        /^([a-z]+)\.view\.([a-z]+)/
      ],
      compose: function(click, view) {
        return 100 * (click / view);
      }
}
```

Source Metrics:
```javascript
{
    counters: {
        "site.click.page": 10,
        "site.view.page": 100
    }
}
````


The engine will store it matching metric to an array [10, 100] where 10 is the first matching regexp and 100 is the second matching regexp. After all matches in metrics the engine starting applying collected metrics to user-defined compose functions. So it will become:

```javascript
click = 10;
view = 100;
```

Applied to: 

```javascript
compose: function(click, view) {
    return 100 * (click / view);
}
```

Will result: 10

The output compose metric will be named like name attribute defined in the rule object. The sharps are back reference to the matching strings, so: 

#0 = site
#1 = page

Then, output metric will be:

site.ctr.page = 10

The final metrics object to be flushed to backends will look like:

```javascript
{
    counters: {
        "site.click.page": 10,
        "site.view.page": 100,
        "site.ctr.page": 100
    }
}
````

Cheers!