### PR TITLE
Include how many members are in the percentile threshold.

### DIFF
--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -42,8 +42,10 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
 
         for (key2 in pctThreshold) {
           var pct = pctThreshold[key2];
+          var numInThreshold = count;
+
           if (count > 1) {
-            var numInThreshold = Math.round(Math.abs(pct) / 100 * count);
+            numInThreshold = Math.round(Math.abs(pct) / 100 * count);
             if (numInThreshold === 0) {
               continue;
             }
@@ -60,6 +62,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
 
           var clean_pct = '' + pct;
           clean_pct = clean_pct.replace('.', '_').replace('-', 'top');
+          current_timer_data["count_" + clean_pct] = numInThreshold;
           current_timer_data["mean_" + clean_pct] = mean;
           current_timer_data[(pct > 0 ? "upper_" : "lower_") + clean_pct] = thresholdBoundary;
           current_timer_data["sum_" + clean_pct] = sum;


### PR DESCRIPTION
Keep track of how many members are put of the threshold.
