### PR TITLE
postinst script fixed

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -4,14 +4,14 @@ set -e
 
 if [ "$1" = configure ]; then
   # Automatically added by dh_installinit
-  if [ -x "/etc/init.d/statsd" ]; then
-    update-rc.d statsd defaults >/dev/null
-    invoke-rc.d statsd start || exit $?
-  fi
-
   if ! getent passwd _statsd > /dev/null; then
     adduser --system --quiet --home /nonexistent --no-create-home \
       --shell /bin/false --force-badname --group --gecos "StatsD User" _statsd
+  fi
+  
+  if [ -x "/etc/init.d/statsd" ]; then
+    update-rc.d statsd defaults >/dev/null
+    invoke-rc.d statsd start || exit $?
   fi
 
   if ! dpkg-statoverride --list /var/run/statsd >/dev/null 2>&1; then


### PR DESCRIPTION
Hi. Statsd service couldn't start, because user does not exists, and invoke-rc.d couldn't start it, because _statsd user does not been created yet. looks like this patch fixed this.
