### PR TITLE
statsd-proy: reset/delete state of metrics on statsd instances when ring members change [WIP]

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -106,7 +106,7 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
     });
     client.on('data', function(data) {
       var response = data.toString();
-      if (response.indexOf('ERROR') > 0) {
+      if (response.indexOf('ERROR') >= 0) {
         l.log('Received ERROR response while issuing ' + cmd + ' command to ' + node.host + ':' + node.port);
       }
     });


### PR DESCRIPTION
Sending this PR over on req from @draco2003. This code does NOT seem to work as intended. I'm not sure exactly why, I suspect perhaps there's a race condition due to metrics coming in at such a high rate, but it still seems like this approach should work.

I didn't spend too much time on it, however, as simply setting `deleteIdleStats: true` on the statsd side achieved roughly the same goal. Still, I think it would be desirable to have a working reset-on-ring-change function.

I could help test if someone has a better idea on how to approach this.
