### PR TITLE
Update helpers.js

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -18,13 +18,13 @@ function is_valid_packet(fields) {
         return true;
     }
     else if (fields[1] == 'g') {
-        if (!fields[0].match(/^([\-\+\d\.]+$)/)) {
+        if (!fields[0].match(/^([\-\+\d\.EeNa]+$)/)) {
             return false;
         } else {
             return true;
         }
     }
-    else if (!fields[0].match(/^([\d\.]+$)/)) {
+    else if (!fields[0].match(/^([\d\.EeNa]+$)/)) {
         return false;
     }
     // filter out malformed sample rates


### PR DESCRIPTION
The previous regex was catching lines with scientific notation (ending in E or e) as bad lines - continuously writing to the statsd.log file, (using lots of I/O).
Also added 'Na' to regex to prevent NaN messages being logged continuously.
