### PR TITLE
Respect globalPrefix when using legacyNamespace.

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -226,11 +226,11 @@ exports.init = function graphite_init(startup_time, config, events) {
       setsNamespace.push(prefixSet);
     }
   } else {
-      globalNamespace = ['stats'];
-      counterNamespace = ['stats'];
-      timerNamespace = ['stats', 'timers'];
-      gaugesNamespace = ['stats', 'gauges'];
-      setsNamespace = ['stats', 'sets'];
+      globalNamespace = [globalPrefix];
+      counterNamespace = [globalPrefix];
+      timerNamespace = [globalPrefix, 'timers'];
+      gaugesNamespace = [globalPrefix, 'gauges'];
+      setsNamespace = [globalPrefix, 'sets'];
   }
 
   graphiteStats.last_flush = startup_time;


### PR DESCRIPTION
Is there a reason to not be able to set/configure a prefix when legacyNamespace is set to true?

This change will use the value of globalPrefix when legacyNamespace is true. It won't affect new users because the hardcoded prefix was 'stats', and the default for globalPrefix is also 'stats'.

It will affect existing users who are have legacyNamespace set to true _and_ have a useless globalPrefix set already. This seems unlikely, and should only happen if someone messes with the prefixes, ends up with legacyNamespace set to true, and then doesn't clean up their config file before declaring it production-ready. A brief note in the release notes ought to be sufficient to cover users that might be caught by this.

Thanks!
