### PR TITLE
Fix inactive timers flushes

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -103,7 +103,7 @@ function flushMetrics() {
         delete(metrics.timers[timer_key]);
         delete(metrics.timer_counters[timer_key]);
       } else {
-        metrics.timers[timer_key] = [];
+        metrics.timers[timer_key] = [0];
         metrics.timer_counters[timer_key] = 0;
      }
     }


### PR DESCRIPTION
Inactive timers should publish '0' to backend when deleteTimers == false. When the list is empty no value is sent to the backend ending up with gaps in the reported values.
