### PR TITLE
Fix IO redirection in Debian init file

### DIFF
--- a/debian/statsd.init
+++ b/debian/statsd.init
@@ -60,7 +60,7 @@ do_start()
 	start-stop-daemon --start --quiet -m --pidfile $PIDFILE --startas $DAEMON --chuid $USER:$USER --background --test > /dev/null \
 		|| return 1
 	start-stop-daemon --start --quiet -m --pidfile $PIDFILE --startas $DAEMON --chuid $USER:$USER --background --no-close --chdir $CHDIR -- \
-		$DAEMON_ARGS >> /var/log/statsd/statsd.log 2> /var/log/$NAME-stderr.log \
+		$DAEMON_ARGS >> /var/log/$NAME/$NAME.log 2> /var/log/$NAME/stderr.log \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
 	# to handle requests from services started subsequently which depend


### PR DESCRIPTION
Send STDOUT and STDERR to the appropriate files
