### PR TITLE
support regexp in histogram config

### DIFF
--- a/docs/metric_types.md
+++ b/docs/metric_types.md
@@ -67,6 +67,11 @@ Examples:
         [ { metric: 'foo', bins: [] },
           { metric: '', bins: [ 50, 100, 150, 200, 'inf'] } ]
 
+* histogram for all timers match a given pattern:
+
+        [ { metric: 'geo.*.pages.*.load', bins: [] },
+          { metric: '', bins: [ 100, 200, 500, 1000, 'inf'] } ]
+
 Note:
 
 * first match for a metric wins.

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -96,6 +96,8 @@ Optional Variables:
                       equal class interval and catchall for outliers:
                      [ { metric: 'foo', bins: [] },
                        { metric: '', bins: [ 50, 100, 150, 200, 'inf'] } ]
+                    * histogram for all timers match 'geo.*.pages.*':
+                     [ { metric: '', bins: [ 1000, 2000, 5000, 'inf'] } ]
 
 */
 {

--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -91,7 +91,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         conf = histogram || [];
         bins = [];
         for (var i = 0; i < conf.length; i++) {
-            if (key.indexOf(conf[i].metric) > -1) {
+            if ((new RegExp(conf[i].metric)).test(key)) {
                 bins = conf[i].bins;
                 break;
             }


### PR DESCRIPTION
the current histogram config use plain text match, but sometimes we need to match metrics on the same pattern, so I added support for regexp in histogram config
