### PR TITLE
Add counter and sum of squares to timer stats

### DIFF
--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -30,11 +30,15 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         var max = values[count - 1];
 
         var cumulativeValues = [min];
+        var cumulSumSquaresValues = [min * min];
         for (var i = 1; i < count; i++) {
             cumulativeValues.push(values[i] + cumulativeValues[i-1]);
+            cumulSumSquaresValues.push((values[i] * values[i]) +
+                                       cumulSumSquaresValues[i - 1]);
         }
 
         var sum = min;
+        var sumSquares = min * min;
         var mean = min;
         var thresholdBoundary = max;
 
@@ -53,9 +57,12 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
             if (pct > 0) {
               thresholdBoundary = values[numInThreshold - 1];
               sum = cumulativeValues[numInThreshold - 1];
+              sumSquares = cumulSumSquaresValues[numInThreshold - 1];
             } else {
               thresholdBoundary = values[count - numInThreshold];
               sum = cumulativeValues[count - 1] - cumulativeValues[count - numInThreshold - 1];
+              sumSquares = cumulSumSquaresValues[count - 1] -
+                cumulSumSquaresValues[count - numInThreshold - 1];
             }
             mean = sum / numInThreshold;
           }
@@ -66,10 +73,12 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
           current_timer_data["mean_" + clean_pct] = mean;
           current_timer_data[(pct > 0 ? "upper_" : "lower_") + clean_pct] = thresholdBoundary;
           current_timer_data["sum_" + clean_pct] = sum;
+          current_timer_data["sum_squares_" + clean_pct] = sumSquares;
 
         }
 
         sum = cumulativeValues[count-1];
+        sumSquares = cumulSumSquaresValues[count-1];
         mean = sum / count;
 
         var sumOfDiffs = 0;
@@ -87,6 +96,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
         current_timer_data["count"] = timer_counters[key];
         current_timer_data["count_ps"] = timer_counters[key] / (flushInterval / 1000);
         current_timer_data["sum"] = sum;
+        current_timer_data["sum_squares"] = sumSquares;
         current_timer_data["mean"] = mean;
         current_timer_data["median"] = median;
 

--- a/test/process_metrics_tests.js
+++ b/test/process_metrics_tests.js
@@ -46,7 +46,7 @@ module.exports = {
     test.done();
   },
   timers_single_time: function(test) {
-    test.expect(8);
+    test.expect(9);
     this.metrics.timers['a'] = [100];
     this.metrics.timer_counters['a'] = 1;
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
@@ -57,12 +57,13 @@ module.exports = {
     test.equal(1, timer_data.count);
     test.equal(10, timer_data.count_ps);
     test.equal(100, timer_data.sum);
+    test.equal(100 * 100, timer_data.sum_squares);
     test.equal(100, timer_data.mean);
     test.equal(100, timer_data.median);
     test.done();
   },
     timers_multiple_times: function(test) {
-    test.expect(8);
+    test.expect(9);
     this.metrics.timers['a'] = [100, 200, 300];
     this.metrics.timer_counters['a'] = 3;
     pm.process_metrics(this.metrics, 100, this.time_stamp, function(){});
@@ -73,12 +74,14 @@ module.exports = {
     test.equal(3, timer_data.count);
     test.equal(30, timer_data.count_ps);
     test.equal(600, timer_data.sum);
+    test.equal(100 * 100 + 200 * 200 + 300 * 300,
+               timer_data.sum_squares);
     test.equal(200, timer_data.mean);
     test.equal(200, timer_data.median);
     test.done();
   },
     timers_single_time_single_percentile: function(test) {
-    test.expect(3);
+    test.expect(4);
     this.metrics.timers['a'] = [100];
     this.metrics.timer_counters['a'] = 1;
     this.metrics.pctThreshold = [90];
@@ -87,10 +90,11 @@ module.exports = {
     test.equal(100, timer_data.mean_90);
     test.equal(100, timer_data.upper_90);
     test.equal(100, timer_data.sum_90);
+    test.equal(100 * 100, timer_data.sum_squares_90);
     test.done();
   },
     timers_single_time_multiple_percentiles: function(test) {
-    test.expect(7);
+    test.expect(9);
     this.metrics.timers['a'] = [100];
     this.metrics.timer_counters['a'] = 1;
     this.metrics.pctThreshold = [90, 80];
@@ -100,13 +104,15 @@ module.exports = {
     test.equal(100, timer_data.mean_90);
     test.equal(100, timer_data.upper_90);
     test.equal(100, timer_data.sum_90);
+    test.equal(100 * 100, timer_data.sum_squares_90);
     test.equal(100, timer_data.mean_80);
     test.equal(100, timer_data.upper_80);
     test.equal(100, timer_data.sum_80);
+    test.equal(100 * 100, timer_data.sum_squares_80);
     test.done();
   },
     timers_multiple_times_single_percentiles: function(test) {
-    test.expect(4);
+    test.expect(5);
     this.metrics.timers['a'] = [100, 200, 300];
     this.metrics.timer_counters['a'] = 3;
     this.metrics.pctThreshold = [90];
@@ -116,10 +122,12 @@ module.exports = {
     test.equal(200, timer_data.mean_90);
     test.equal(300, timer_data.upper_90);
     test.equal(600, timer_data.sum_90);
+    test.equal(100 * 100 + 200 * 200 + 300 * 300,
+               timer_data.sum_squares_90);
     test.done();
   },
     timers_multiple_times_multiple_percentiles: function(test) {
-    test.expect(9);
+    test.expect(11);
     this.metrics.timers['a'] = [100, 200, 300];
     this.metrics.timer_counters['a'] = 3;
     this.metrics.pctThreshold = [90, 80];
@@ -130,11 +138,15 @@ module.exports = {
     test.equal(200, timer_data.mean_90);
     test.equal(300, timer_data.upper_90);
     test.equal(600, timer_data.sum_90);
+    test.equal(100 * 100 + 200 * 200 + 300 * 300,
+               timer_data.sum_squares_90);
 
     test.equal(2, timer_data.count_80);
     test.equal(150, timer_data.mean_80);
     test.equal(200, timer_data.upper_80);
     test.equal(300, timer_data.sum_80);
+    test.equal(100 * 100 + 200 * 200,
+               timer_data.sum_squares_80);
     test.done();
   },
     timers_sampled_times: function(test) {


### PR DESCRIPTION
This adds the count of members in each percentile and the sum of squares to the precalculated timer statistics. These are both used to do rapid calculation of standard deviation/variance over an arbitrary number of consecutive intervals: http://en.wikipedia.org/wiki/Standard_deviation#Rapid_calculation_methods.

This is a superset of the patch in https://github.com/etsy/statsd/pull/342

These pre-calculated values can be leveraged by the Librato backend to reduce duplicated timer processing.
