### PR TITLE
Persist counts on timers with no values.

### DIFF
--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -20,9 +20,10 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
     }
 
     for (key in timers) {
+      var current_timer_data = {};
+
       if (timers[key].length > 0) {
         timer_data[key] = {};
-        var current_timer_data = {};
 
         var values = timers[key].sort(function (a,b) { return a-b; });
         var count = values.length;
@@ -112,9 +113,13 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
           current_timer_data['histogram'][bin_name] = freq;
         }
 
-        timer_data[key] = current_timer_data;
+      } else {
+
+        current_timer_data["count"] = current_timer_data["count_ps"] = 0;
 
       }
+
+      timer_data[key] = current_timer_data;
     }
 
     statsd_metrics["processing_time"] = (Date.now() - starttime);

--- a/test/graphite_delete_counters_tests.js
+++ b/test/graphite_delete_counters_tests.js
@@ -180,9 +180,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 2);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 0');
+            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 3');
 
             var bad_lines_seen_value_test = function(post){
               var mykey = 'stats_counts.statsd.bad_lines_seen';
@@ -213,9 +213,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 2);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 2');
+            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 3');
 
             var testtimervalue_test = function(post){
               var mykey = 'stats.timers.a_test_value.mean_90';
@@ -246,9 +246,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 2);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 2');
+            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 3');
 
             var testavgvalue_test = function(post){
               var mykey = 'stats.a_test_value';

--- a/test/graphite_legacy_tests.js
+++ b/test/graphite_legacy_tests.js
@@ -172,9 +172,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 1');
+            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 4');
 
             var testtimervalue_test = function(post){
               var mykey = 'stats.timers.a_test_value.mean_90';
@@ -205,9 +205,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 1');
+            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 4');
 
             var testavgvalue_test = function(post){
               var mykey = 'stats.a_test_value';

--- a/test/graphite_legacy_tests_statsprefix.js
+++ b/test/graphite_legacy_tests_statsprefix.js
@@ -173,9 +173,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsprefix.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsprefix.numStats should be 1');
+            test.ok(_.any(hashes,numstat_test), 'statsprefix.numStats should be 4');
 
             var testtimervalue_test = function(post){
               var mykey = 'stats.timers.a_test_value.mean_90';
@@ -206,9 +206,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'statsprefix.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsprefix.numStats should be 1');
+            test.ok(_.any(hashes,numstat_test), 'statsprefix.numStats should be 4');
 
             var testavgvalue_test = function(post){
               var mykey = 'stats.a_test_value';

--- a/test/graphite_tests.js
+++ b/test/graphite_tests.js
@@ -174,9 +174,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 2);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 0');
+            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 3');
 
             var bad_lines_seen_value_test = function(post){
               var mykey = 'stats.counters.statsd.bad_lines_seen.count';
@@ -207,9 +207,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'stats.statsd.numStats should be 1');
+            test.ok(_.any(hashes,numstat_test), 'stats.statsd.numStats should be 4');
 
             var testtimervalue_test = function(post){
               var mykey = 'stats.timers.a_test_value.mean_90';
@@ -278,9 +278,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsd.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 3');
+            test.ok(_.any(hashes,numstat_test), 'statsd.numStats should be 4');
 
             var testavgvalue_test = function(post){
               var mykey = 'stats.counters.a_test_value.rate';

--- a/test/graphite_tests_statsprefix.js
+++ b/test/graphite_tests_statsprefix.js
@@ -174,9 +174,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsprefix.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 2);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsprefix.numStats should be 0');
+            test.ok(_.any(hashes,numstat_test), 'statsprefix.numStats should be 3');
 
             var bad_lines_seen_value_test = function(post){
               var mykey = 'stats.counters.statsprefix.bad_lines_seen.count';
@@ -207,9 +207,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsprefix.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'stats.statsprefix.numStats should be 1');
+            test.ok(_.any(hashes,numstat_test), 'stats.statsprefix.numStats should be 4');
 
             var testtimervalue_test = function(post){
               var mykey = 'stats.timers.a_test_value.mean_90';
@@ -240,9 +240,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsprefix.numStats';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'statsprefix.numStats should be 3');
+            test.ok(_.any(hashes,numstat_test), 'statsprefix.numStats should be 4');
 
             var testavgvalue_test = function(post){
               var mykey = 'stats.counters.a_test_value.rate';

--- a/test/graphite_tests_statssuffix.js
+++ b/test/graphite_tests_statssuffix.js
@@ -176,9 +176,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsd.numStats.statssuffix';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 2);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
             };
-            test.ok(_.any(hashes,numstat_test), 'numStats.statssuffix should be 0');
+            test.ok(_.any(hashes,numstat_test), 'numStats.statssuffix should be 3');
 
             var bad_lines_seen_value_test = function(post){
               var mykey = 'stats.counters.statsd.bad_lines_seen.count.statssuffix';
@@ -209,9 +209,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsd.numStats.statssuffix';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'stats.statsd.numStats.statssuffix should be 1');
+            test.ok(_.any(hashes,numstat_test), 'stats.statsd.numStats.statssuffix should be 4');
 
             var testtimervalue_test = function(post){
               var mykey = 'stats.timers.a_test_value.mean_90.statssuffix';
@@ -242,9 +242,9 @@ module.exports = {
             });
             var numstat_test = function(post){
               var mykey = 'stats.statsd.numStats.statssuffix';
-              return _.include(_.keys(post),mykey) && (post[mykey] == 3);
+              return _.include(_.keys(post),mykey) && (post[mykey] == 4);
             };
-            test.ok(_.any(hashes,numstat_test), 'numStats.statssuffix should be 3');
+            test.ok(_.any(hashes,numstat_test), 'numStats.statssuffix should be 4');
 
             var testavgvalue_test = function(post){
               var mykey = 'stats.counters.a_test_value.rate.statssuffix';


### PR DESCRIPTION
This change brings timer `count` and `count_ps` functionality into
parity with the standard counters by causing them to send zeroes when
their timers haven't been seen during the flush interval.

Fixes #370.
