### PR TITLE
fixed a link (datadog backend)

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -32,7 +32,7 @@ queues and third-party services.
 
 ## Available Third-party backends
 - [amqp-backend](https://github.com/mrtazz/statsd-amqp-backend)
-- [datadog-backend](https://github.com/datadog/statsd)
+- [datadog-backend](https://github.com/DataDog/statsd-datadog-backend)
 - [ganglia-backend](https://github.com/jbuchbinder/statsd-ganglia-backend)
 - [hosted graphite backend](https://github.com/hostedgraphite/statsdplugin)
 - [instrumental backend](https://github.com/collectiveidea/statsd-instrumental-backend)


### PR DESCRIPTION
Link to datadog-backend was deprecated
