### PR TITLE
Updates winser to v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "optionalDependencies": {
     "node-syslog":"1.1.7",
     "hashring":"1.0.1",
-    "winser": "=0.0.11"
+    "winser": "=0.1.6"
   },
   "engines": {
     "node" : ">=0.8"


### PR DESCRIPTION
A change to a dependency (sequence?) of winser v0.0.11 meant
thatthe service install script was no longer working.
