### PR TITLE
Respect command line arguments when overriding the process title.

### DIFF
--- a/lib/process_mgmt.js
+++ b/lib/process_mgmt.js
@@ -22,6 +22,10 @@ exports.set_title = function(config) {
        process.title = config.title;
    }
  } else {
-   process.title = 'statsd';
+   // Respect command line arguments when overriding the process title.
+   cmdline = process.argv.slice(2);
+   cmdline.unshift('statsd');
+
+   process.title = cmdline.join(" ");
  }
 }


### PR DESCRIPTION
This preserves extra command line arguments (like the path to the config file) when overriding the process title. A process title of 'statsd' is, for some users, less useful than 'node statsd.js /path/to/config.js' and this aims to be a reasonable compromise.
