### PR TITLE
Adding a config option, automaticConfigReload, controlling the behaviour...

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -99,6 +99,8 @@ Optional Variables:
                      [ { metric: 'foo', bins: [] },
                        { metric: '', bins: [ 50, 100, 150, 200, 'inf'] } ]
 
+  automaticConfigReload: whether to watch the config file and reload it when it
+                         changes. The default is true. Set this to false to disable.
 */
 {
   graphitePort: 2003

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,7 +24,9 @@ var Configurator = function (file) {
   this.updateConfig();
 
   fs.watch(file, function (event, filename) {
-      if (event == 'change') { self.updateConfig(); }
+    if (event == 'change' && self.config.automaticConfigReload != false) {
+      self.updateConfig();
+    }
   });
 };
 


### PR DESCRIPTION
... of the config file reloading feature.

This adds a config option to disable the automatic config reloading feature. This feature is good, but can be operationally unpredictable. Ops/admins expect that changes made to a config file will not take effect until the service is restarted. Restarting a service (and possibly crashing it) when a half-complete config is saved (accidentally or out of habit) is surprising, and operations people hate surprises. :)

The default behaviour is not changed, most users won't notice or care.
