### PR TITLE
Graphite backend: Applying the globalPrefix value in legacyNamespace mode

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -66,6 +66,10 @@ var post_stats = function graphite_post_stats(statString) {
         statString += namespace + '.graphiteStats.flush_time'     + globalSuffix + flush_time     + ts_suffix;
         statString += namespace + '.graphiteStats.flush_length'   + globalSuffix + flush_length   + ts_suffix;
 
+        // Apply the globalPrefix in legacyNamespace mode.
+        if(legacyNamespace && globalPrefix.length > 0)
+           statString = globalPrefix + "." + statString.slice(0, -1).replace(/\n/g, "\n" + globalPrefix + ".") + "\n";
+
         var starttime = Date.now();
         this.write(statString);
         this.end();


### PR DESCRIPTION
It's useful to be able to specify a prefix for everything, even in legacyNamespace mode. This does that. It's a little hacky/dense, but the alternative is a lot of changes in many places, which will be a bigger diff and harder to be certain the impact is limited.

This is specifically useful for hooking up statsd to services like Hosted Graphite, but it should be more generally useful too.

I believe it also fixes a problem with the naming of the "global" prefix, where it's not actually "global". The naming implies it prefixes everything, but it only works in the new namespace mode.

Users using legacyNamespace with no globalPrefix won't be affected. Users not using legacyNamespace won't be affected. Users who are using legacyNamespace and who have a globalPrefix currently configured, but ignored, will be affected. This is likely to be a very small set of users who have tested not using the legacy namespace, but gone back to using it and not cleaned up their config. A message in the release notes should be sufficient to warn these users.
