### PR TITLE
Fractional values in histogram bins

### DIFF
--- a/lib/process_metrics.js
+++ b/lib/process_metrics.js
@@ -122,7 +122,7 @@ var process_metrics = function (metrics, flushInterval, ts, flushCallback) {
           for (; i < count && (bins[bin_i] == 'inf' || values[i] < bins[bin_i]); i++) {
             freq += 1;
           }
-          bin_name = 'bin_' + bins[bin_i];
+          bin_name = 'bin_' + bins[bin_i].replace('.', '_');
           current_timer_data['histogram'][bin_name] = freq;
         }
 


### PR DESCRIPTION
If you pass the following histogram config
`[ { metric: 'render', bins: [ 0.01, 0.1, 1, 10, 'inf'] } ]`
statsd would send to carbon something like that

```
render.histogram.bin_0.01 value timestamp
render.histogram.bin_0.1 value timestamp
render.histogram.bin_1 value timestamp
render.histogram.bin_10 value timestamp
render.histogram.bin_inf value timestamp
```

First two metrics will make dirs in whisper database, which are undesirable for structure.

I think line 111 should be changed in process_metrics.js to

``` js
bin_name = 'bin_' + bins[bin_i].replace('.', '_');
```
