### PR TITLE
Added the -w0 to the Usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The basic line protocol expects metrics to be sent via UDP in the format:
 So the simplest way to send in metrics from your command line if you have
 StatsD running on localhost would be:
 
-    echo "foo:1|c" | nc -u 127.0.0.1 8125
+    echo "foo:1|c" | nc -u -w0 127.0.0.1 8125
 
 More Specific Topics
 --------


### PR DESCRIPTION
Without the `-w0` the `nc` command hangs.
