### PR TITLE
Remove port as required in exampleConfig

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -1,9 +1,4 @@
 /*
-
-Required Variables:
-
-  port:             StatsD listening port [default: 8125]
-
 Graphite Required Variables:
 
 (Leave these unset to avoid sending stats to Graphite.


### PR DESCRIPTION
It's not required anymore as it has a default value
