### PR TITLE
Fix NODE_BIN from pre-start script not in scope for exec

### DIFF
--- a/debian/statsd.upstart
+++ b/debian/statsd.upstart
@@ -22,4 +22,7 @@ pre-start script
     [ -n $NODE_BIN ] || { stop; exit 0; }
 end script
 
-exec $NODE_BIN stats.js /etc/statsd/localConfig.js
+script
+    NODE_BIN=$(which nodejs || which node)
+    $NODE_BIN stats.js /etc/statsd/localConfig.js
+end script


### PR DESCRIPTION
Upstart script resulted in "/bin/sh: 1: exec: stats.js: not found" in /var/log/upstart/statsd.log due to a variable scope issue.
