### PR TITLE
statsd.upstart: exec to remove parent shell from process list

### DIFF
--- a/debian/statsd.upstart
+++ b/debian/statsd.upstart
@@ -24,5 +24,5 @@ end script
 
 script
     NODE_BIN=$(which nodejs || which node)
-    $NODE_BIN stats.js /etc/statsd/localConfig.js
+    exec $NODE_BIN stats.js /etc/statsd/localConfig.js
 end script


### PR DESCRIPTION
Changes ps output from:

```
1234 _statsd sh
1235 _statsd \_ statsd /etc/statsd/localConfig.js
```

to just one second line without intermediate shell process waiting for node.
