### PR TITLE
added tcp repeater. merged with udp repeater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+config.js
+*.idea

--- a/backends/repeater.js
+++ b/backends/repeater.js
@@ -1,44 +1,94 @@
 /*jshint node:true, laxcomma:true */
 
 var util = require('util')
-  , dgram = require('dgram')
-  , logger = require('../lib/logger');
+    , dgram = require('dgram')
+    , logger = require('../lib/logger');
 
-var l;
-var debug;
+var net = require('net')
+    , generic_pool = require('generic-pool');
 
-function RepeaterBackend(startupTime, config, emitter){
-  var self = this;
-  this.config = config.repeater || [];
-  this.sock = (config.repeaterProtocol == 'udp6') ?
+function UDPRepeater(config, logger) {
+    var self = this;
+    this.debug = config.debug;
+    this.logger = logger
+    this.config = config;
+    this.sock = (config.repeaterProtocol == 'udp6') ?
         dgram.createSocket('udp6') :
         dgram.createSocket('udp4');
-  // Attach DNS error handler
-  this.sock.on('error', function (err) {
-    if (debug) {
-      l.log('Repeater error: ' + err);
-    }
-  });
-  // attach
-  emitter.on('packet', function(packet, rinfo) { self.process(packet, rinfo); });
+    // Attach DNS error handler
+    this.sock.on('error', function (err) {
+        if (self.debug) {
+            self.logger.log('UDP Repeater error: ' + err);
+        }
+    });
 }
 
-RepeaterBackend.prototype.process = function(packet, rinfo) {
-  var self = this;
-  hosts = self.config;
-  for(var i=0; i<hosts.length; i++) {
-    self.sock.send(packet,0,packet.length,hosts[i].port,hosts[i].host,
-                   function(err,bytes) {
-      if (err && debug) {
-        l.log(err);
-      }
-    });
-  }
+UDPRepeater.prototype.process = function (packet, rinfo) {
+    var self = this;
+    var hosts = self.config.hosts;
+    for (var i = 0; i < hosts.length; i++) {
+        self.sock.send(packet, 0, packet.length, hosts[i].port, hosts[i].host, function (err, bytes) {
+            if (err && self.debug) {
+                self.logger.log(err);
+            }
+        });
+    }
 };
 
-exports.init = function(startupTime, config, events, logger) {
-  var instance = new RepeaterBackend(startupTime, config, events);
-  debug = config.debug;
-  l = logger;
-  return true;
+function TCPRepeater(config, logger) {
+    var self = this;
+    this.debug = config.debug;
+    this.logger = logger
+    this.connectionPool = generic_pool.Pool({
+        name: 'connectionPool',
+        max: config.maxConnections,
+        create: function(callback) {
+            var conn = net.createConnection(config.port, config.host);
+            conn.addListener('error', function (connectionException) {
+                self.logger.log('TCP Repeater error: ' + connectionException);
+                self.connectionPool.destroy(this)
+                callback(connectionException, null);
+            });
+            conn.on('connect', function () {
+                if (self.debug) {
+                    self.logger.log("connected to " + config.host + ":" + config.port);
+                }
+                callback(null, this);
+            });
+        },
+        destroy: function(conn) {
+            if (self.debug) {
+                self.logger.log("connection is destroyed");
+            }
+            conn.destroy();
+        }
+    });
+}
+
+TCPRepeater.prototype.process = function (packet, rinfo) {
+    var self = this;
+    self.connectionPool.acquire(function(err, conn) {
+        if (err) {
+            self.logger.log("connection error. data is lost: "+packet);
+        }
+        else {
+            conn.write(packet + "\n");
+        }
+        self.connectionPool.release(conn);
+    });
+}
+
+exports.init = function (startupTime, config, events, logger) {
+    var instance = {};
+    if (config.repeater.udp && config.repeater.udp.enabled) {
+        instance = new UDPRepeater(config.repeater.udp, logger);
+    }
+    else if (config.repeater.tcp && config.repeater.tcp.enabled){
+        instance = new TCPRepeater(config.repeater.tcp, logger);
+    }
+    events.on('packet', function (packet, rinfo) {
+        instance.process(packet, rinfo);
+    });
+
+    return true;
 };

--- a/backends/repeaterTcp.js
+++ b/backends/repeaterTcp.js
@@ -1,0 +1,57 @@
+/*jshint node:true, laxcomma:true */
+
+var util = require('util')
+    , dgram = require('dgram')
+    , logger = require('../lib/logger');
+
+var net = require('net');
+var generic_pool = require('generic-pool');
+
+var l;
+var debug;
+var connectionConfig;
+
+var connectionPool = generic_pool.Pool({
+    name: 'connectionPool',
+    max: 10,
+    create: function(callback) {
+        var conn = net.createConnection(connectionConfig.port, connectionConfig.host);
+        conn.addListener('error', function (connectionException) {
+            l.log(connectionException);
+            callback(connectionException, this);
+        });
+        conn.on('connect', function () {
+            l.log("connected to "+connectionConfig.host+":"+connectionConfig.port);
+            callback(null, this);
+        });
+    },
+    destroy: function(conn) {
+        l.log("connection is destroyed");
+        conn.destroy();
+    }
+});
+
+function RepeaterTcpBackend(startupTime, config, emitter) {
+    emitter.on('packet', function (packet, rinfo) {
+        connectionPool.acquire(function(err, conn) {
+            if (err) {
+                l.log("connection error. data is lost: "+packet);
+            }
+            else {
+                conn.write(packet + "\n");
+            }
+            connectionPool.release(conn);
+        });
+    });
+}
+
+exports.init = function (startupTime, config, events, logger) {
+    l = logger;
+    l.log("initialized RepeaterTcpBackend");
+    connectionConfig = config.repeaterTcp || {}
+    l.log("connecting by config "+JSON.stringify(connectionConfig));
+
+    var instance = new RepeaterTcpBackend(startupTime, config, events);
+    debug = config.debug;
+    return true;
+};


### PR DESCRIPTION
repeater's config is changed slightly. There was a bug on old repeater config. You can't specify repeaterProtocol on an array.

{
    graphitePort: 9997
    , graphiteHost: "localhost"
    , port: 8125
    , backends: [ "./backends/repeater" ]
    , repeater:
    {
        udp: {
            enabled: true
            , debug: true
            , repeaterProtocol: "udp6"
            , hosts: [{host: "localhost", port: 9997}]
        }
        , tcp: {
            enabled: true
            , debug: true
            , maxConnections: 10
            , host: "localhost"
            , port: 9997
        }
    }

}