### PR TITLE
Add servers/*.js to debian package

### DIFF
--- a/debian/statsd.install
+++ b/debian/statsd.install
@@ -2,4 +2,5 @@ stats.js	/usr/share/statsd
 lib/*.js /usr/share/statsd/lib
 backends/*.js  /usr/share/statsd/backends
 lib/*.js  /usr/share/statsd/lib
+servers/*.js /usr/share/statsd/servers
 debian/localConfig.js	/etc/statsd


### PR DESCRIPTION
The changes that added a tcp server option broke creating deb packages because the server/*.js files were not included in the package.

The error would look like this when starting statsd:
`
Error: Cannot find module './servers/udp'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at startServer (/usr/share/statsd/stats.js:54:19)
    at /usr/share/statsd/stats.js:190:20
    at null.<anonymous> (/usr/share/statsd/lib/config.js:40:5)
    at EventEmitter.emit (events.js:95:17)
    at /usr/share/statsd/lib/config.js:20:12
    at fs.js:268:14
`

This change simply add's the server/*.js files into the package.
