### PR TITLE
Adding proxy management interface

### DIFF
--- a/docs/cluster_proxy.md
+++ b/docs/cluster_proxy.md
@@ -20,6 +20,8 @@ It handles a simple health check that dynamically recalculates the hashring if a
 
 Config Options are documented in the [exampleProxyConfig.js][exampleProxyConfig.js]
 
+It has a management interface that returns a json with the status of each node in the hashring.
+
 Notes
 --------------
 In your statsd configuration make sure to have the following configuration set: `deleteIdleStats: true`


### PR DESCRIPTION
As the cluster proxy does not have a management interface, I've added a web interface that returns a json with the status of each node in the hashring.

This makes monitoring the statsd proxy nodes easier