### PR TITLE
Fix prettyprint option for console backend

### DIFF
--- a/backends/console.js
+++ b/backends/console.js
@@ -33,7 +33,7 @@ ConsoleBackend.prototype.flush = function(timestamp, metrics) {
   };
 
   if(this.config.prettyprint) {
-    console.log(util.inspect(out, false, 5, true));
+    console.log(util.inspect(out, {depth: 5, colors: true}));
   } else {
     console.log(out);
   }


### PR DESCRIPTION
Pretty was using an invalid invocation of util.inspect(). Perhaps it was
valid pre-v0.10, but inspect now takes an options object.