### PR TITLE
validate against negative sampling

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,7 +8,7 @@
  * Returns true for a valid packet and false otherwise
  */
 function isNumber(str) {
-    return Boolean(str && !isNaN(str));
+    return Boolean(str && !isNaN(str) && str[0] != '-');
 }
 
 function is_valid_packet(fields) {

--- a/test/helpers_tests.js
+++ b/test/helpers_tests.js
@@ -112,6 +112,7 @@ module.exports = {
     test.equals(helpers.is_valid_packet(['345345', 'ms', '@.']), false);
     test.equals(helpers.is_valid_packet(['345345', 'ms', '@.1.']), false);
     test.equals(helpers.is_valid_packet(['345345', 'ms', '@.1.2.3']), false);
+    test.equals(helpers.is_valid_packet(['345345', 'ms', '@-1.0']), false);
     test.done();
   },
 


### PR DESCRIPTION
Lines with negative sampling make server crash.

```
metric_name:43|ms|@-1.000000
```

will cause crash at `stats.js:240`:

```
sampleRate = Number(fields[2].match(/^@([\d\.]+)/)[1]);
```

because there is no match for `([\d\.]+)` group. Solution is to add additional validation against negative numbers in `helpers.js`.
