### PR TITLE
Validate negative sampling

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,6 +11,15 @@ function isNumber(str) {
     return Boolean(str && !isNaN(str));
 }
 
+function isValidSampleRate(str) {
+    var validSampleRate = false;
+    if(str.length > 1 && str[0] === '@') {
+        var numberStr = str.substring(1);
+        validSampleRate = isNumber(numberStr) && numberStr[0] != '-';
+    }
+    return validSampleRate;
+}
+
 function is_valid_packet(fields) {
 
     // test for existing metrics type
@@ -19,8 +28,8 @@ function is_valid_packet(fields) {
     }
 
     // filter out malformed sample rates
-    if (fields[2] !== undefined) {
-        if (fields[2].length <= 1 || fields[2][0] != '@' || !isNumber(fields[2].substring(1))) {
+    if(fields[2] !== undefined) {
+        if(!isValidSampleRate(fields[2])) {
             return false;
         }
     }

--- a/test/helpers_tests.js
+++ b/test/helpers_tests.js
@@ -112,6 +112,7 @@ module.exports = {
     test.equals(helpers.is_valid_packet(['345345', 'ms', '@.']), false);
     test.equals(helpers.is_valid_packet(['345345', 'ms', '@.1.']), false);
     test.equals(helpers.is_valid_packet(['345345', 'ms', '@.1.2.3']), false);
+    test.equals(helpers.is_valid_packet(['345345', 'ms', '@-1.0']), false);
     test.done();
   },
 


### PR DESCRIPTION
Lines with negative sampling make server crash.

```
metric_name:43|ms|@-1.000000
```

will cause crash at `stats.js:240`:

```
sampleRate = Number(fields[2].match(/^@([\d\.]+)/)[1]);
```

because there is no match for `([\d\.]+)` group. Solution is to add additional validation against negative numbers in `helpers.js`.