### PR TITLE
Enable packaging at https://packager.io/gh/pkgr/statsd

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,8 @@
+targets:
+  ubuntu-14.04:
+  ubuntu-12.04:
+  debian-7:
+  centos-6:
+before:
+  - mv packager/Procfile .
+after_install: ./packager/postinst

--- a/packager/Procfile
+++ b/packager/Procfile
@@ -1,0 +1,1 @@
+web: node stats.js ${STATSD_CONFIG:="config.js"}

--- a/packager/postinst
+++ b/packager/postinst
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+APP_NAME="statsd"
+CLI="$APP_NAME"
+APP_USER=$(${CLI} config:get APP_USER)
+APP_GROUP=$(${CLI} config:get APP_GROUP)
+APP_CONFIG="/etc/${APP_NAME}/config.js"
+
+[ -f "$APP_CONFIG" ] || cp /opt/${APP_NAME}/exampleConfig.js $APP_CONFIG
+chown $APP_USER.$APP_GROUP $APP_CONFIG
+ln -f -s $APP_CONFIG /opt/$APP_NAME/config.js
+chmod 0640 $APP_CONFIG
+
+${CLI} scale web=1 || true


### PR DESCRIPTION
This pull request enables automatic packaging of statsd for Debian/Ubuntu/CentOS/RHEL using packager.io. The packages come with init scripts and a facility to install additional npm modules if needed.

Example installation instructions at https://packager.io/gh/pkgr/statsd/install?bid=15#ubuntu-14-04-statsd