### PR TITLE
Allow negative values for timing (ms) stats.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -32,7 +32,7 @@ function is_valid_packet(fields) {
         case 'g':
             return isNumber(fields[0]);
         case 'ms':
-            return isNumber(fields[0]) && Number(fields[0]) >= 0;
+            return isNumber(fields[0]);
         default:
             if (!isNumber(fields[0])) {
                 return false;


### PR DESCRIPTION
Hello,

would you consider this pull request which allows negative values in timing stats? It sometimes may happen, when source and receiving systems have wrongly synchronised time and values will be negative. Not filtering such values may show this problem right away (in graphite), not when occasionally looking into logs of statsd. 

Thanks.
