### PR TITLE
Update hashring to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "optionalDependencies": {
     "node-syslog":"1.1.7",
-    "hashring":"1.0.1",
+    "hashring":"3.0.0",
     "winser": "=0.1.6"
   },
   "engines": {


### PR DESCRIPTION
old version hashring fails to build with node v0.11+, so please upgrade hashring to latest, and it (3.0) works well
with node v0.11 (tested)