### PR TITLE
Support loading multiple servers.

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -15,14 +15,22 @@ Optional Variables:
                     the default graphite backend will be loaded. 
                     * example for console and graphite:
                     [ "./backends/console", "./backends/graphite" ]
-  server:           the server to load. The server must exist by name in the directory
+
+  servers:          an array of server configurations.
+                    If not specified, the server, address,
+                    address_ipv6, and port top-level configuration
+                    options are used to configure a single server for
+                    backwards-compatibility
+                    Each server configuration supports the following keys:
+    server:         the server to load. The server must exist by name in the directory
                     servers/. If not specified, the default udp server will be loaded.
                     * example for tcp server:
                     "./servers/tcp"
+    address:        address to listen on [default: 0.0.0.0]
+    address_ipv6:   defines if the address is an IPv4 or IPv6 address [true or false, default: false]
+    port:           port to listen for messages on [default: 8125]
+
   debug:            debug flag [default: false]
-  address:          address to listen on [default: 0.0.0.0]
-  address_ipv6:     defines if the address is an IPv4 or IPv6 address [true or false, default: false]
-  port:             port to listen for messages on [default: 8125]
   mgmt_address:     address to run the management TCP interface on
                     [default: 0.0.0.0]
   mgmt_port:        port to run the management TCP interface on [default: 8126]

--- a/stats.js
+++ b/stats.js
@@ -23,7 +23,7 @@ var sets = {};
 var counter_rates = {};
 var timer_data = {};
 var pctThreshold = null;
-var flushInterval, keyFlushInt, serverLoaded, mgmtServer;
+var flushInterval, keyFlushInt, serversLoaded, mgmtServer;
 var startup_time = Math.round(new Date().getTime() / 1000);
 var backendEvents = new events.EventEmitter();
 var healthStatus = config.healthStatus || 'up';
@@ -198,13 +198,12 @@ config.configFile(process.argv[2], function (config) {
   if (config.keyNameSanitize !== undefined) {
     keyNameSanitize = config.keyNameSanitize;
   }
-    if (!serverLoaded) {
+  if (!serversLoaded) {
+
     // key counting
     var keyFlushInterval = Number((config.keyFlush && config.keyFlush.interval) || 0);
 
-    // The default server is UDP
-    var server = config.server || './servers/udp'
-    serverLoaded = startServer(config, server, function (msg, rinfo) {
+    var handlePacket = function (msg, rinfo) {
       backendEvents.emit('packet', msg, rinfo);
       counters[packets_received]++;
       var packet_data = msg.toString();
@@ -279,7 +278,16 @@ config.configFile(process.argv[2], function (config) {
       }
 
       stats.messages.last_msg_seen = Math.round(new Date().getTime() / 1000);
-    });
+    }
+
+    // If config.servers isn't specified, use the top-level config for backwards-compatibility
+    var server_config = config.servers || [config]
+    for (var i = 0; i < server_config.length; i++) {
+      // The default server is UDP
+      var server = server_config[i].server || './servers/udp'
+      startServer(server_config[i], server, handlePacket)
+    }
+    serversLoaded = true
 
     mgmtServer = net.createServer(function(stream) {
       stream.setEncoding('ascii');


### PR DESCRIPTION
Example config looks something like this:

```
{
  servers: [
    {server: './servers/tcp', address: '0.0.0.0', port: 6125}
  , {server: './servers/udp', port: 6125}
  ]
}
```

In the absence of a servers key, we look at the same variables under the top-level config, which is backwards compatible with the current behavior.