### PR TITLE
Set nitpick

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -158,7 +158,7 @@ var flush_stats = function graphite_flush(ts, metrics) {
 
   for (key in sets) {
     var namespace = setsNamespace.concat(sk(key));
-    statString += namespace.join(".") + '.count' + globalSuffix + sets[key].values().length + ts_suffix;
+    statString += namespace.join(".") + '.count' + globalSuffix + sets[key].size() + ts_suffix;
     numStats += 1;
   }
 

--- a/lib/set.js
+++ b/lib/set.js
@@ -14,7 +14,7 @@ Set.prototype = {
   },
   insert: function(value) {
     if (value) {
-      this.store[value] = value;
+      this.store[value] = true;
     }
   },
   clear: function() {

--- a/lib/set.js
+++ b/lib/set.js
@@ -26,6 +26,9 @@ Set.prototype = {
       values.push(value);
     }
     return values;
+  },
+  size: function() {
+    return Object.keys(this.store).length;
   }
 };
 

--- a/test/set_tests.js
+++ b/test/set_tests.js
@@ -37,5 +37,18 @@ module.exports = {
     s.insert('b');
     test.equal(2, s.values().length);
     test.done();
+  },
+  size_is_correct: function(test) {
+    test.expect(5);
+    var s = new set.Set();
+    test.equal(0, s.size());
+    s.insert('a');
+    test.equal(1, s.size());
+    s.insert('a');
+    test.equal(1, s.size());
+    s.insert('b');
+    test.equal(2, s.size());
+    test.equal(s.values().length, s.size());
+    test.done();
   }
 }


### PR DESCRIPTION
two minor tweaks to set.js...

1. the first is to have the sets only store a boolean to indicate that a key is stored rather than duplicating the key into the value.

2. the second adds the size method, which simply returns the size of the set. It seems that we only care about values for getting the actual size, so it makes sense to me to do this on the set itself.