### PR TITLE
Pin to new node-syslog release that fixes #510

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "temp": "0.4.x"
   },
   "optionalDependencies": {
-    "node-syslog":"schamane/node-syslog#30d44555",
+    "node-syslog":"1.2.0",
     "hashring":"3.1.0",
     "winser": "=0.1.6"
   },


### PR DESCRIPTION
Just updating the node-syslog version in dependencies now that you can install 1.2.0 and run statsd without having it crash!