### PR TITLE
Change deleteIdleStats default value from false to true

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -46,7 +46,7 @@ Optional Variables:
     log:            location of log file for frequent keys [default: STDOUT]
   deleteIdleStats:  don't send values to graphite for inactive counters, sets, gauges, or timers
                     as opposed to sending 0.  For gauges, this unsets the gauge (instead of sending
-                    the previous value). Can be individually overriden. [default: false]
+                    the previous value). Can be individually overriden. [default: true]
   deleteGauges:     don't send values to graphite for inactive gauges, as opposed to sending the previous value [default: false]
   deleteTimers:     don't send values to graphite for inactive timers, as opposed to sending 0 [default: false]
   deleteSets:       don't send values to graphite for inactive sets, as opposed to sending 0 [default: false]

--- a/stats.js
+++ b/stats.js
@@ -93,7 +93,7 @@ function flushMetrics() {
     // TODO: a lot of this should be moved up into an init/constructor so we don't have to do it every
     // single flushInterval....
     // allows us to flag all of these on with a single config but still override them individually
-    conf.deleteIdleStats = conf.deleteIdleStats !== undefined ? conf.deleteIdleStats : false;
+    conf.deleteIdleStats = conf.deleteIdleStats !== undefined ? conf.deleteIdleStats : true;
     if (conf.deleteIdleStats) {
       conf.deleteCounters = conf.deleteCounters !== undefined ? conf.deleteCounters : true;
       conf.deleteTimers = conf.deleteTimers !== undefined ? conf.deleteTimers : true;


### PR DESCRIPTION
Statsd has a deleteIdleStats option that is responsible for removing unused statistics.  The default value is false, which means once statsd has seen a stat, it will repeatedly send it forever regardless of weather it sees that stat come in again.  I propose a default value of true, which is far less likely to cause harm.  In practice, stat names change regularly and I've seen this feature cause more than 500,000 unused, worthless stats to be sent to a single Graphite instance every five seconds without end.  Even a well-spec'd Graphite instance can struggle to keep up with that volume of data, especially since that's not including the actual live data that people want.  Graphite does not include good facilities for identifying where a given stat comes from so identifying statsd as the source of the flood of stats took many man-hours.  Please save many headaches and remove unused stats by default by setting deleteIdleStats to true out of the box.