### PR TITLE
implements a tcp repeater, with tests

### DIFF
--- a/backends/repeater.js
+++ b/backends/repeater.js
@@ -2,43 +2,152 @@
 
 var util = require('util')
   , dgram = require('dgram')
-  , logger = require('../lib/logger');
+  , logger = require('../lib/logger')
+  , Pool = require('generic-pool').Pool
+  , net = require('net');
+
 
 var l;
 var debug;
+var instance;
 
-function RepeaterBackend(startupTime, config, emitter){
+function logerror(err) {
+  if(err && debug) {
+    l.log(err);
+  }
+}
+
+
+
+function UDPRepeaterBackend(startupTime, config, emitter) {
   var self = this;
   this.config = config.repeater || [];
   this.sock = (config.repeaterProtocol == 'udp6') ?
         dgram.createSocket('udp6') :
         dgram.createSocket('udp4');
+
   // Attach DNS error handler
   this.sock.on('error', function (err) {
     if (debug) {
       l.log('Repeater error: ' + err);
     }
   });
+
   // attach
   emitter.on('packet', function(packet, rinfo) { self.process(packet, rinfo); });
 }
 
-RepeaterBackend.prototype.process = function(packet, rinfo) {
+
+UDPRepeaterBackend.prototype.process = function(packet, rinfo) {
   var self = this;
-  hosts = self.config;
+  var hosts = self.config;
   for(var i=0; i<hosts.length; i++) {
-    self.sock.send(packet,0,packet.length,hosts[i].port,hosts[i].host,
-                   function(err,bytes) {
-      if (err && debug) {
-        l.log(err);
-      }
-    });
+    self.sock.send(packet,0,packet.length,hosts[i].port,hosts[i].host,logerror);
   }
 };
 
-exports.init = function(startupTime, config, events, logger) {
-  var instance = new RepeaterBackend(startupTime, config, events);
+UDPRepeaterBackend.prototype.stop = function(cb) {
+  this.sock.close();
+  cb();
+};
+
+
+
+var TCPRepeaterBackend = function(startupTime, config, emitter) {  
+  this.config = config;
+  this.pools = [];
+  
+  var targets = this.config.repeater || [];
+  for(var i = 0; i < targets.length; i++) {
+    this.pools.push(this.createPool(targets[i]));
+  }
+
+  var self = this;
+  emitter.on('packet', function(packet, rinfo) { self.process(packet, rinfo); });
+};
+
+
+TCPRepeaterBackend.prototype.createPool = function(server) {  
+  return Pool({
+    name: server.host + ':' + server.port,
+
+    create: function(cb) {
+      var client = net.connect(server.port, server.host);
+
+      function connectError(err) { cb(err, null); }
+
+      client.on('connect', function() {
+        client.removeListener('error', connectError);
+        cb(null, client);
+      });
+      
+      client.on('error', connectError);
+    },
+
+    destroy: function(client) {
+      client.end();
+    },
+
+    max: 5
+  });
+};
+
+TCPRepeaterBackend.prototype.process = function(packet, rinfo) {
+  function send(buf, pool) {
+    pool.acquire(function(err, client) {
+      if(err) {
+        logerror(err);
+      } else {
+        client.write(buf, function() {
+          pool.release(client);
+        });
+      }
+    });
+  }
+
+  for(var i = 0; i < this.pools.length; i++) {
+    send(new Buffer(packet.toString() + "\n"), this.pools[i]);
+  }
+};
+
+
+TCPRepeaterBackend.prototype.stop = function(cb) {
+  var self = this;
+  function drain_pool(i) {
+    if(i == self.pools.length) {
+      cb();
+      return;
+    }
+
+    self.pools[i].drain(function() {
+      self.pools[i].destroyAllNow(function() {
+        drain_pool(i + 1);
+      });
+    });
+  }
+  
+  drain_pool(0);
+};
+
+
+exports.init = function(startupTime, config, emitter, logger) {
   debug = config.debug;
   l = logger;
+
+  var proto = config.repeaterProtocol;
+  if(proto == 'tcp') {
+    instance = new TCPRepeaterBackend(startupTime, config, emitter);
+  } else {
+    instance = new UDPRepeaterBackend(startupTime, config, emitter);
+  }
+
   return true;
+};
+
+
+exports.stop = function(cb) {
+  if(instance) {
+    instance.stop(cb);
+    instance = null;
+  }
 };

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -83,8 +83,8 @@ Optional Variables:
                     e.g. [ { host: '10.10.10.10', port: 8125 },
                            { host: 'observer', port: 88125 } ]
 
-  repeaterProtocol: whether to use udp4 or udp6 for repeaters.
-                    ["udp4" or "udp6", default: "udp4"]
+  repeaterProtocol: whether to use udp4, udp6, or tcp for repeaters.
+                    ["udp4," "udp6", or "tcp" default: "udp4"]
 
   histogram:        for timers, an array of mappings of strings (to match metrics) and
                     corresponding ordered non-inclusive upper limits of bins.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "version": "0.7.2",
   "dependencies": {
+    "generic-pool": "2.2.0"
   },
   "devDependencies": {
     "nodeunit": "0.7.x",

--- a/servers/tcp.js
+++ b/servers/tcp.js
@@ -7,7 +7,7 @@ function rinfo(tcpstream, data) {
     this.size = data.length;
 }
 
-exports.start = function(config, callback){
+exports.start = function(config, callback) {
   var server = net.createServer(function(stream) {
       stream.setEncoding('ascii');
 
@@ -24,5 +24,7 @@ exports.start = function(config, callback){
   });
 
   server.listen(config.port || 8125, config.address || undefined);
+  this.server = server;
+
   return true;
 };

--- a/servers/udp.js
+++ b/servers/udp.js
@@ -7,9 +7,7 @@ exports.start = function(config, callback) {
   var server = dgram.createSocket(udp_version, callback);
 
   server.bind(config.port || 8125, config.address || undefined);
-  server.on('listening', function() {
-    l.log('server is listening');
-  });
+  this.server = server;
 
   return true;
 };

--- a/servers/udp.js
+++ b/servers/udp.js
@@ -1,8 +1,6 @@
-var dgram  = require('dgram'),
-    Logger = require('../lib/logger').Logger;
+var dgram  = require('dgram');
 
 exports.start = function(config, callback) {
-  var l = new Logger(config.log || {});
   var udp_version = config.address_ipv6 ? 'udp6' : 'udp4';
   var server = dgram.createSocket(udp_version, callback);
 

--- a/servers/udp.js
+++ b/servers/udp.js
@@ -1,8 +1,15 @@
-var dgram  = require('dgram');
+var dgram  = require('dgram'),
+    Logger = require('../lib/logger').Logger;
 
-exports.start = function(config, callback){
+exports.start = function(config, callback) {
+  var l = new Logger(config.log || {});
   var udp_version = config.address_ipv6 ? 'udp6' : 'udp4';
   var server = dgram.createSocket(udp_version, callback);
+
   server.bind(config.port || 8125, config.address || undefined);
+  server.on('listening', function() {
+    l.log('server is listening');
+  });
+
   return true;
 };

--- a/test/repeater_tests.js
+++ b/test/repeater_tests.js
@@ -77,19 +77,17 @@ StatsDClient.prototype.send = function(data, cb) {
 var RepeaterServer = function(port, server_port) {
   this.port = port || 8125;
   this.server_port = server_port || 9125;
+  this.config = {
+    repeater: [{ host: '127.0.0.1', port: this.server_port }],
+    repeaterProtocol: 'udp4',
+    server: './servers/udp',
+    port: this.port,
+    backends: [ './backends/repeater' ]
+  };
 };
 
 RepeaterServer.prototype.start = function(cb) {
-  var config_path = writeconfig(
-    "{ "
-      + "repeater: [{ host: '127.0.0.1', port: " + this.server_port + "}] "
-      + ", repeaterProtocol: 'udp4' "
-      + ", server: './servers/udp' "
-      + ", dumpMessages: true "
-      + ", port: " + this.port + " "
-      + ", backends: [ './backends/repeater' ] "
-      + "}"
-  );
+  var config_path = writeconfig(JSON.stringify(this.config));
   log('Wrote config file %s', config_path);
   log('Starting repeater listening on', this.port, 
       'forwarding to', this.server_port);

--- a/test/repeater_tests.js
+++ b/test/repeater_tests.js
@@ -153,18 +153,6 @@ module.exports = {
     });
   },
 
-  fake_server_is_working: function(test) {
-    test.expect(1);
-    var server = this.server;
-    var client = new StatsDClient(this.server.port, 'localhost');
-
-    client.send('foobar', function() {
-      server.collect(100, function(messages) {
-        test.equal(messages[0], 'foobar');
-        test.done();
-      });
-    });
-  },
 
   repeater_works: function(test) {
     test.expect(1);
@@ -172,7 +160,7 @@ module.exports = {
     var client = new StatsDClient(this.repeater.port, '127.0.0.1');
 
     client.send('foobar', function() {
-      server.collect(200, function(messages) {
+      server.collect(100, function(messages) {
         test.equal(messages[0], 'foobar');
         test.done();
       });

--- a/test/repeater_tests.js
+++ b/test/repeater_tests.js
@@ -1,0 +1,182 @@
+var net        = require('net'),
+    spawn      = require('child_process').spawn,
+    fs         = require('fs'),
+    temp       = require('temp'),
+    dgram      = require('dgram');
+
+
+var writeconfig = function(text) {
+  var info = temp.openSync({ suffix: '-statsdconf.js' });
+  fs.writeSync(info.fd, text);
+  return info.path;
+};
+
+
+function log() {
+  //console.log.apply(console, arguments);
+}
+
+
+var FakeStatsDServer = function() {
+  this.port = 9125;
+};
+
+FakeStatsDServer.prototype.start = function(cb) {
+  this.sock = dgram.createSocket('udp4');
+
+  var self = this;
+  this.sock.on('listening', function() {
+    log('Fake statsd server listening on', self.port);
+    cb();
+  });
+
+  this.sock.bind(this.port);
+};
+
+FakeStatsDServer.prototype.stop = function(cb) {
+  this.sock.close();
+  cb();
+};
+
+FakeStatsDServer.prototype.collect = function(timeout, cb) {
+  var sock = this.sock;
+
+  var messages = [];
+  function onmsg(msg) {
+    log('Received %s', msg.toString());
+    messages.push(msg.toString());
+  }
+
+  sock.on('message', onmsg);
+
+  setTimeout(function() {
+    sock.removeListener('message', onmsg);
+    cb(messages);
+  }, timeout);
+};
+
+
+var StatsDClient = function(port, host) {
+  this.host = host || '127.0.0.1';
+  this.port = port || 8125;
+};
+
+StatsDClient.prototype.send = function(data, cb) {
+  var buf = new Buffer(data);
+  var sock = dgram.createSocket('udp4');
+  sock.send(buf, 0, buf.length, this.port, this.host, function(err, bytes) {
+    if(err) {
+      throw err;
+    }
+    sock.close();
+    cb();
+  });
+};
+
+
+var RepeaterServer = function(port, server_port) {
+  this.port = port || 8125;
+  this.server_port = server_port || 9125;
+};
+
+RepeaterServer.prototype.start = function(cb) {
+  var config_path = writeconfig(
+    "{ "
+      + "repeater: [{ host: '127.0.0.1', port: " + this.server_port + "}] "
+      + ", repeaterProtocol: 'udp4' "
+      + ", server: './servers/udp' "
+      + ", dumpMessages: true "
+      + ", port: " + this.port + " "
+      + ", backends: [ './backends/repeater' ] "
+      + "}"
+  );
+  log('Wrote config file %s', config_path);
+  log('Starting repeater listening on', this.port, 
+      'forwarding to', this.server_port);
+  
+  this.server_up = true;
+  this.ok_to_die = false;
+  var self = this;
+  var r = spawn('node', ['stats.js', config_path]);
+
+  r.on('exit', function(code) {
+    self.server_up = false;
+    if(!self.ok_to_die) {
+      console.log('node server unexpectedly quit with code:', code);
+      process.exit();
+    }
+    self.exit_callback();
+  });
+  
+  r.stderr.on('data', function(data) {
+    console.log('stderr: ' + data.toString().replace(/\n$/,''));
+  });
+
+  r.stdout.on('data', function (data) {
+    if (data.toString().match(/server is listening/)) {
+      log('Repeater server is up');
+      cb();
+    }
+  });
+
+  this.repeater = r;
+};
+
+RepeaterServer.prototype.stop = function(cb) {
+  this.ok_to_die = true;
+  if(this.server_up) {
+    this.exit_callback = cb;
+    this.repeater.kill();
+  } else {
+    cb();
+  }
+};
+
+
+
+module.exports = {
+
+  setUp: function(cb) {
+    this.server = new FakeStatsDServer();
+    this.repeater = new RepeaterServer();
+
+    var repeater = this.repeater;
+    this.server.start(function() {
+      repeater.start(cb);
+    });
+  },
+
+  tearDown: function(cb) {
+    var repeater = this.repeater;
+    this.server.stop(function() {
+      repeater.stop(cb);
+    });
+  },
+
+  fake_server_is_working: function(test) {
+    test.expect(1);
+    var server = this.server;
+    var client = new StatsDClient(this.server.port, 'localhost');
+
+    client.send('foobar', function() {
+      server.collect(100, function(messages) {
+        test.equal(messages[0], 'foobar');
+        test.done();
+      });
+    });
+  },
+
+  repeater_works: function(test) {
+    test.expect(1);
+    var server = this.server;
+    var client = new StatsDClient(this.repeater.port, '127.0.0.1');
+
+    client.send('foobar', function() {
+      server.collect(200, function(messages) {
+        test.equal(messages[0], 'foobar');
+        test.done();
+      });
+    });
+  }
+
+};


### PR DESCRIPTION
This adds test coverage for the (existing) udp repeater, and adds a tcp version. 

The only config change is that `repeaterProtocol` can now be `"tcp"`.
