### PR TITLE
Explicitly close UDP sockets in Ruby examples

### DIFF
--- a/examples/ruby_example.rb
+++ b/examples/ruby_example.rb
@@ -68,6 +68,7 @@ class Statsd
         value = data[stat]
         sock.send("#{stat}:#{value}", 0, @@config[:host], @@config[:port])
       end
+      sock.close
     end
   end
 end

--- a/examples/ruby_example2.rb
+++ b/examples/ruby_example2.rb
@@ -77,6 +77,7 @@ class Statsd
         send_data = "%s:%s" % [stat, val]
         udp.send send_data, 0, host, port
       end
+      udp.close
     rescue => e
       puts e.message
     end


### PR DESCRIPTION
Not closing the sockets explicitely causes them to hang around longer than expected, and can cause issues when the number of open sockets exceeds system limits.