### PR TITLE
Add npm to deb package dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 8.0.0)
 
 Package: statsd
 Architecture: all
-Depends: nodejs (>= 0.10), adduser
+Depends: nodejs (>= 0.10), adduser, npm
 Description: Stats aggregation daemon
   A network daemon for aggregating statistics (counters and timers),
   rolling them up, then sending them to graphite.


### PR DESCRIPTION
npm is used in debian/postinst script.