### PR TITLE
Repeater hosts can be configured to send on flush

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -90,6 +90,9 @@ Optional Variables:
                     packets should be "repeated" (duplicated to).
                     e.g. [ { host: '10.10.10.10', port: 8125 },
                            { host: 'observer', port: 88125 } ]
+                    each packet will be repeated by default. In order to only
+                    repeat to a host on 'flush' events, configure a host as follows:
+                           { host: "1.2.3.4", port: 8125, on: "flush" }
 
   repeaterProtocol: whether to use udp4, udp6, or tcp for repeaters.
                     ["udp4," "udp6", or "tcp" default: "udp4"]


### PR DESCRIPTION
We've found that when sending each packet individually using statsd, we easily overwhelm our network. Instead, we configure all of our statsd instances to flush to a repeater, which then figures out what to do with the packets.

A few issues with this pull request: I have only started with the UDP repeater, because it's extremely simple. I'm hoping to add the same functionality to the TCP repeater, but need to spend some time learning how the TCP repeater works. I also have not added tests. I was searching for tests that cover packet flushing in the main statsd codebase to use as an example, but was not able to find them. If someone sees this and can give some advice, that would be appreciated!