### PR TITLE
Fix: only install production dependencies

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -4,7 +4,7 @@ set -e
 
 if [ "$1" = configure ]; then
   # Automatically added by dh_installinit
-  (cd /usr/share/statsd && /usr/bin/npm install)
+  (cd /usr/share/statsd && /usr/bin/npm install --production)
 
   if ! getent passwd _statsd > /dev/null; then
     adduser --system --quiet --home /nonexistent --no-create-home \


### PR DESCRIPTION
The `devDependencies` don't seem to be necessary in production. Food for thought?