### PR TITLE
SystemD enable autostart fails

### DIFF
--- a/debian/statsd-proxy.service
+++ b/debian/statsd-proxy.service
@@ -9,3 +9,4 @@ User=_statsd
 ExecStart=/usr/bin/nodejs /usr/share/statsd/proxy.js /etc/statsd/proxyConfig.js
 
 [Install]
+WantedBy=multi-user.target

--- a/debian/statsd.service
+++ b/debian/statsd.service
@@ -9,3 +9,4 @@ User=_statsd
 ExecStart=/usr/bin/nodejs /usr/share/statsd/stats.js /etc/statsd/localConfig.js
 
 [Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
On Debian 8, `systemctl enable statsd` fails with message:

> The unit files have no [Install] section. They are not meant to be enabled using systemctl.

It is because debian/*.service files are missing configuration in Install section. See attached commit.