### PR TITLE
Fix date in debian changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,7 +7,7 @@ statsd (0.7.2) unstable; urgency=low
   * Remove init script that does not work in favor of just having upstart
   * Fix node version dependency
 
- -- Joseph Hughes <jhughes@itriagehealth.com>  Thurs, 16 Apr 2014 13:03:10 +0200
+ -- Joseph Hughes <jhughes@itriagehealth.com>  Thu, 16 Apr 2014 13:03:10 +0200
 
 statsd (0.6.0-1) unstable; urgency=low
 


### PR DESCRIPTION
Otherwise we get a perl date parsing error while trying to do dpkg-buildpackage