### PR TITLE
change subconfig(at statsd.js 330:15) to local variable

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -315,7 +315,7 @@ config.configFile(process.argv[2], function (config) {
                 stream.write(prop + ": " + config[prop] + "\n");
                 continue;
               }
-              subconfig = config[prop];
+              var subconfig = config[prop];
               for (var subprop in subconfig) {
                 if (!subconfig.hasOwnProperty(subprop)) {
                   continue;


### PR DESCRIPTION
As you known, without 'var', the variable 'subconfig' is global variable .
But I find that the 'subconfig'  only used between 330 and 335 in statsd.js 

```javascript
330               subconfig = config[prop];
331               for (var subprop in subconfig) {
332                 if (!subconfig.hasOwnProperty(subprop)) {
333                   continue;
334                 }
335                 stream.write(prop + " > " + subprop + ": " + subconfig[subprop] + "\n");
336               }
```

I mind that You don't want subconfig to pollute global.