### PR TITLE
statsd-proxy management server

### DIFF
--- a/docs/admin_interface.md
+++ b/docs/admin_interface.md
@@ -1,20 +1,29 @@
 TCP Stats Interface
--------------------
+===================
 
 A really simple TCP management interface is available by default on port 8126
 or overriden in the configuration file. Inspired by the memcache stats approach
 this can be used to monitor a live statsd server.  You can interact with the
 management server by telnetting to port 8126, the following commands are
-available:
+available based on the running server.
+
+Common commands
+---------------
+
+* health [up|down] - a way to get/set the health status of statsd. Alone will get you the current health status. Passing a second command will set the status to the new value. Accepted values are _up_ and _down_.
+* config - a dump of the current configuration
+* quit - close the connection from the server side
+
+Statsd specific commands
+------------------------
 
 * stats - some stats about the running server
 * counters - a dump of all the current counters
 * gauges - a dump of all the current gauges
 * timers - a dump of the current timers
 * delcounters - delete a counter or folder of counters
-* delgauges - delete a gauge or folder of gauges 
+* delgauges - delete a gauge or folder of gauges
 * deltimers - delete a timer or folder of timers
-* health - a way to set the health status of statsd
 
 The stats output currently will give you:
 
@@ -31,7 +40,7 @@ Or you can use the del command to delete a folder of metrics like this :
 
     #to delete counters sandbox.test.*
     echo "delcounters sandbox.test.*" | nc 127.0.0.1 8126
-    
+
 
 Each backend will also publish a set of statistics, prefixed by its module name.
 
@@ -55,3 +64,12 @@ The health output:
 * using health up or health down, you can change the current health status.
 * the healthStatus configuration option allows you to set the default health status at start.
 
+Statsd Proxy specific commands
+------------------------------
+
+* status - the status of the current server
+
+The __status__ output currently will give you:
+
+* uptime: the number of seconds elapsed since statsd proxy started
+* nodes: a space separated list of host:port for each active node in the ring

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,7 +10,7 @@ var Configurator = function (file) {
   var oldConfig = {};
 
   this.updateConfig = function () {
-    util.log('reading config file: ' + file);
+    util.log('[' + process.pid + '] reading config file: ' + file);
 
     fs.readFile(file, function (err, data) {
       if (err) { throw err; }
@@ -40,4 +40,3 @@ exports.configFile = function(file, callbackFunc) {
     callbackFunc(config.config, config.oldConfig);
   });
 };
-

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -52,3 +52,23 @@ function is_valid_packet(fields) {
 }
 
 exports.is_valid_packet = is_valid_packet;
+
+exports.writeConfig = function(config, stream) {
+  stream.write("\n");
+  for (var prop in config) {
+    if (!config.hasOwnProperty(prop)) {
+      continue;
+    }
+    if (typeof config[prop] !== 'object') {
+      stream.write(prop + ": " + config[prop] + "\n");
+      continue;
+    }
+    subconfig = config[prop];
+    for (var subprop in subconfig) {
+      if (!subconfig.hasOwnProperty(subprop)) {
+        continue;
+      }
+      stream.write(prop + " > " + subprop + ": " + subconfig[subprop] + "\n");
+    }
+  }
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -49,6 +49,6 @@ function is_valid_packet(fields) {
             return true;
     }
 
-};
+}
 
 exports.is_valid_packet = is_valid_packet;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,15 +24,18 @@ Logger.prototype = {
       }
       this.util.log(type + ": " + msg);
     } else {
+      var level;
       if (!type) {
-        type = this.level;
-        if (!this.util[type]) {
-          throw "Undefined log level: " + type;
-        }
-      } else if (type == 'debug') {
-        type = "LOG_DEBUG";
+        level = this.level;
+      } else {
+        level = "LOG_" + type.toUpperCase();
       }
-      this.util.log(this.util[type], msg);
+
+      if (!this.util[level]) {
+        throw "Undefined log level: " + level;
+      }
+
+      this.util.log(this.util[level], msg);
     }
   }
 };

--- a/lib/mgmt_server.js
+++ b/lib/mgmt_server.js
@@ -1,0 +1,24 @@
+/*jshint node:true, laxcomma:true */
+
+var net = require('net');
+
+exports.start = function(config, on_data_callback, on_error_callback) {
+  var server = net.createServer(function(stream) {
+      stream.setEncoding('ascii');
+
+      stream.on('data', function(data) {
+        var cmdline = data.trim().split(" ");
+        var cmd = cmdline.shift();
+
+        on_data_callback(cmd, cmdline, stream);
+      });
+
+      stream.on('error', function(err) {
+        on_error_callback(err, stream);
+      });
+  });
+
+  server.listen(config.mgmt_port || 8126, config.mgmt_address || undefined);
+
+  return true;
+};

--- a/proxy.js
+++ b/proxy.js
@@ -33,7 +33,7 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
 
   if (forkCount > 1 && cluster.isMaster) {
     logPrefix += "[master] ";
-    log("forking " + forkCount + " childs");
+    log("forking " + forkCount + " childs", "INFO");
 
     for (var i = 0; i < forkCount; i++) {
       cluster.fork();
@@ -104,7 +104,7 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
 
     // break the retreived host to pass to the send function
     if (statsd_host === undefined) {
-      log('Warning: No backend statsd nodes available!');
+      log('Warning: No backend statsd nodes available!', 'WARNING');
     } else {
       var host_config = statsd_host.split(':');
 
@@ -143,7 +143,7 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
           node_status[node_id]++;
         }
         if (node_status[node_id] < 2) {
-          log('Removing node ' + node_id + ' from the ring.');
+          log('Removing node ' + node_id + ' from the ring.', 'WARNING');
           ring.remove(node_id);
         }
       } else {
@@ -151,7 +151,7 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
           if (node_status[node_id] > 0) {
             var new_server = {};
             new_server[node_id] = 100;
-            log('Adding node ' + node_id + ' to the ring.');
+            log('Adding node ' + node_id + ' to the ring.', 'WARNING');
             ring.add(new_server);
           }
         }
@@ -166,11 +166,11 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
           node_status[node_id]++;
         }
         if (node_status[node_id] < 2) {
-          log('Removing node ' + node_id + ' from the ring.');
+          log('Removing node ' + node_id + ' from the ring.', 'WARNING');
           ring.remove(node_id);
         }
       } else {
-        log('Error during healthcheck on node ' + node_id + ' with ' + e.code);
+        log('Error during healthcheck on node ' + node_id + ' with ' + e.code, 'ERROR');
       }
     });
   }

--- a/proxy.js
+++ b/proxy.js
@@ -1,3 +1,5 @@
+/*jshint node:true, laxcomma:true */
+
 var dgram    = require('dgram')
   , net      = require('net')
   , events   = require('events')
@@ -26,7 +28,7 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
   var logPrefix = "[" + process.pid + "] ";
   var log = function(msg, type) {
     l.log(logPrefix + msg, type);
-  }
+  };
 
 
   if (forkCount > 1 && cluster.isMaster) {
@@ -65,15 +67,18 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
   var server = dgram.createSocket(udp_version, function (msg, rinfo) {
     // Convert the raw packet to a string (defaults to UTF8 encoding)
     var packet_data = msg.toString();
+    var current_metric
+      , bits
+      , key;
     // If the packet contains a \n then it contains multiple metrics
     if (packet_data.indexOf("\n") > -1) {
       var metrics;
       metrics = packet_data.split("\n");
       // Loop through the metrics and split on : to get mertric name for hashing
       for (var midx in metrics) {
-        var current_metric = metrics[midx];
-        var bits = current_metric.split(':');
-        var key = bits.shift();
+        current_metric = metrics[midx];
+        bits = current_metric.split(':');
+        key = bits.shift();
         if (current_metric !== '') {
           var new_msg = new Buffer(current_metric);
           packet.emit('send', key, new_msg);
@@ -82,9 +87,9 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
 
     } else {
       // metrics needs to be an array to fake it for single metric packets
-      var current_metric = packet_data;
-      var bits = current_metric.split(':');
-      var key = bits.shift();
+      current_metric = packet_data;
+      bits = current_metric.split(':');
+      key = bits.shift();
       if (current_metric !== '') {
         packet.emit('send', key, msg);
       }

--- a/proxy.js
+++ b/proxy.js
@@ -170,10 +170,16 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
               var cmdaction = parameters[0].toLowerCase();
               if (cmdaction === 'up') {
                 healthStatus = 'up';
-                process.send({ healthStatus: healthStatus });
+                if (forkCount > 0) {
+                  // Notify the other forks
+                  process.send({ healthStatus: healthStatus });
+                }
               } else if (cmdaction === 'down') {
                 healthStatus = 'down';
-                process.send({ healthStatus: healthStatus });
+                if (forkCount > 0) {
+                  // Notify the other forks
+                  process.send({ healthStatus: healthStatus });
+                }
               }
             }
             stream.write("health: " + healthStatus + "\n");

--- a/stats.js
+++ b/stats.js
@@ -206,11 +206,12 @@ config.configFile(process.argv[2], function (config) {
     var handlePacket = function (msg, rinfo) {
       backendEvents.emit('packet', msg, rinfo);
       counters[packets_received]++;
+      var metrics;
       var packet_data = msg.toString();
       if (packet_data.indexOf("\n") > -1) {
-        var metrics = packet_data.split("\n");
+        metrics = packet_data.split("\n");
       } else {
-        var metrics = [ packet_data ] ;
+        metrics = [ packet_data ] ;
       }
 
       for (var midx in metrics) {
@@ -278,16 +279,16 @@ config.configFile(process.argv[2], function (config) {
       }
 
       stats.messages.last_msg_seen = Math.round(new Date().getTime() / 1000);
-    }
+    };
 
     // If config.servers isn't specified, use the top-level config for backwards-compatibility
-    var server_config = config.servers || [config]
+    var server_config = config.servers || [config];
     for (var i = 0; i < server_config.length; i++) {
       // The default server is UDP
-      var server = server_config[i].server || './servers/udp'
-      startServer(server_config[i], server, handlePacket)
+      var server = server_config[i].server || './servers/udp';
+      startServer(server_config[i], server, handlePacket);
     }
-    serversLoaded = true
+    serversLoaded = true;
 
     mgmtServer = net.createServer(function(stream) {
       stream.setEncoding('ascii');
@@ -431,8 +432,8 @@ config.configFile(process.argv[2], function (config) {
     config.flushInterval = flushInterval;
 
     if (config.backends) {
-      for (var i = 0; i < config.backends.length; i++) {
-        loadBackend(config, config.backends[i]);
+      for (var j = 0; j < config.backends.length; j++) {
+        loadBackend(config, config.backends[j]);
       }
     } else {
       // The default backend is graphite

--- a/stats.js
+++ b/stats.js
@@ -1,7 +1,6 @@
 /*jshint node:true, laxcomma:true */
 
 var util    = require('util')
-  , net    = require('net')
   , config = require('./lib/config')
   , helpers = require('./lib/helpers')
   , fs     = require('fs')
@@ -10,6 +9,7 @@ var util    = require('util')
   , set = require('./lib/set')
   , pm = require('./lib/process_metrics')
   , process_mgmt = require('./lib/process_mgmt')
+  , mgmt_server = require('./lib/mgmt_server')
   , mgmt = require('./lib/mgmt_console');
 
 
@@ -288,47 +288,22 @@ config.configFile(process.argv[2], function (config) {
       var server = server_config[i].server || './servers/udp';
       startServer(server_config[i], server, handlePacket);
     }
-    serversLoaded = true;
 
-    mgmtServer = net.createServer(function(stream) {
-      stream.setEncoding('ascii');
-
-      stream.on('error', function(err) {
-        l.log('Caught ' + err +', Moving on');
-      });
-
-      stream.on('data', function(data) {
-        var cmdline = data.trim().split(" ");
-        var cmd = cmdline.shift();
-
+    mgmt_server.start(
+      config,
+      function(cmd, parameters, stream) {
         switch(cmd) {
           case "help":
             stream.write("Commands: stats, counters, timers, gauges, delcounters, deltimers, delgauges, health, config, quit\n\n");
             break;
 
           case "config":
-            stream.write("\n");
-            for (var prop in config) {
-              if (!config.hasOwnProperty(prop)) {
-                continue;
-              }
-              if (typeof config[prop] !== 'object') {
-                stream.write(prop + ": " + config[prop] + "\n");
-                continue;
-              }
-              subconfig = config[prop];
-              for (var subprop in subconfig) {
-                if (!subconfig.hasOwnProperty(subprop)) {
-                  continue;
-                }
-                stream.write(prop + " > " + subprop + ": " + subconfig[subprop] + "\n");
-              }
-            }
+            helpers.writeConfig(config, stream);
             break;
 
           case "health":
-            if (cmdline.length > 0) {
-              var cmdaction = cmdline[0].toLowerCase();
+            if (parameters.length > 0) {
+              var cmdaction = parameters[0].toLowerCase();
               if (cmdaction === 'up') {
                 healthStatus = 'up';
               } else if (cmdaction === 'down') {
@@ -396,15 +371,15 @@ config.configFile(process.argv[2], function (config) {
             break;
 
           case "delcounters":
-            mgmt.delete_stats(counters, cmdline, stream);
+            mgmt.delete_stats(counters, parameters, stream);
             break;
 
           case "deltimers":
-            mgmt.delete_stats(timers, cmdline, stream);
+            mgmt.delete_stats(timers, parameters, stream);
             break;
 
           case "delgauges":
-            mgmt.delete_stats(gauges, cmdline, stream);
+            mgmt.delete_stats(gauges, parameters, stream);
             break;
 
           case "quit":
@@ -415,12 +390,13 @@ config.configFile(process.argv[2], function (config) {
             stream.write("ERROR\n");
             break;
         }
+      },
+      function(err, stream) {
+        l.log('MGMT: Caught ' + err +', Moving on', 'WARNING');
+      }
+    );
 
-      });
-    });
-
-    mgmtServer.listen(config.mgmt_port || 8126, config.mgmt_address || undefined);
-
+    serversLoaded = true;
     util.log("server is up", "INFO");
 
     pctThreshold = config.percentThreshold || 90;

--- a/stats.js
+++ b/stats.js
@@ -41,7 +41,7 @@ function loadBackend(config, name) {
 
   var ret = backendmod.init(startup_time, config, backendEvents, l);
   if (!ret) {
-    l.log("Failed to load backend: " + name);
+    l.log("Failed to load backend: " + name, "ERROR");
     process.exit(1);
   }
 }
@@ -60,7 +60,7 @@ function startServer(config, name, callback) {
 
   var ret = servermod.start(config, callback);
   if (!ret) {
-    l.log("Failed to load server: " + name);
+    l.log("Failed to load server: " + name, "ERROR");
     process.exit(1);
   }
 }
@@ -421,7 +421,7 @@ config.configFile(process.argv[2], function (config) {
 
     mgmtServer.listen(config.mgmt_port || 8126, config.mgmt_address || undefined);
 
-    util.log("server is up");
+    util.log("server is up", "INFO");
 
     pctThreshold = config.percentThreshold || 90;
     if (!Array.isArray(pctThreshold)) {

--- a/utils/check_statsd_health
+++ b/utils/check_statsd_health
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Check the status of a statsd or statsd proxy connecting directly to the
+# management console.
+
+# This script can be used both for Nagios and Keepalived passing a parameter.
+# The default behaviour is the Nagios one.
+
+OK=0;
+CRITICAL=2;
+UNKNOWN=3;
+KEEPALIVED_CRITICAL=1;
+
+HOST="127.0.0.1"
+PORT="8126"
+MODE_KEEPALIVED=0
+
+print_usage() {
+    echo "Usage: check_statsd_health [-H host] [-P port] [-k]"
+    echo "Options:"
+    echo " -H host  Specify the host to check. [default: 127.0.0.1]"
+    echo " -P port  Specify the port to check. [default: 8126]"
+    echo " -k       Use exit status for Keepalived MISC_CHECK. [default: false]"
+
+    if [[ "${MODE_KEEPALIVED}" -eq "1" ]]; then
+        exit ${KEEPALIVED_CRITICAL}
+    else
+        exit ${UNKNOWN}
+    fi
+}
+
+while getopts ":H:P:k" opt; do
+    case $opt in
+        H) HOST="${OPTARG}";;
+        P) PORT="${OPTARG}";;
+        k) MODE_KEEPALIVED=1;;
+
+        :)
+            echo "Missing mandatory value for option '-${OPTARG}'" >&2
+            print_usage
+            ;;
+
+        \?)
+            echo "Invalid option '${OPTARG}'" >&2
+            print_usage
+            ;;
+
+    esac
+done
+
+HEALTH="$(echo -e "health\n" | nc -q1 "${HOST}" "${PORT}")"
+echo "Statsd '${HOST}:${PORT}' responded: '${HEALTH}'"
+
+if [[ "${HEALTH}" == "health: up" ]]; then
+    exit ${OK}
+else
+    if [[ "${MODE_KEEPALIVED}" -eq "1" ]]; then
+        exit ${KEEPALIVED_CRITICAL}
+    else
+        exit ${CRITICAL}
+    fi
+fi


### PR DESCRIPTION
Added the management server for statsd-proxy:
* Extracted the existing management server into lib/mgmt_server.js
* Moved the input handling of the console into the management server
* Extracted the write configuration in the console into lib/helpers.js
* Added the management server to proxy.js
* Refactored the management server in stats.js
* Added handling of the health status change across all forks in proxy.js
* Updated documentation for the admin interface
* Added check script that can be used by Nagios and Keepalived to monitor a statsd or statsd-proxy instance through the management interface

Additional small changes done along the way:
* When using syslog, automatically translates stdout types to syslog levels
* Added some levels to existing logs
* Fix JSHint warnings

@mrtazz 