### PR TITLE
Allow to use unix domain sockets.

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -29,6 +29,10 @@ Optional Variables:
     address:        address to listen on [default: 0.0.0.0]
     address_ipv6:   defines if the address is an IPv4 or IPv6 address [true or false, default: false]
     port:           port to listen for messages on [default: 8125]
+    socket:         (only for tcp servers) path to unix domain socket which will be used to receive
+                    metrics [default: undefinded]
+    socket_mod:     (only for tcp servers) file mode which should be applied to unix domain socket, relevant
+                    only if socket option is used [default: undefined]
 
   debug:            debug flag [default: false]
   mgmt_address:     address to run the management TCP interface on

--- a/servers/tcp.js
+++ b/servers/tcp.js
@@ -1,4 +1,5 @@
 var net  = require('net');
+var fs = require('fs');
 
 function rinfo(tcpstream, data) {
     this.address = tcpstream.remoteAddress;
@@ -23,8 +24,15 @@ exports.start = function(config, callback) {
       });
   });
 
-  server.listen(config.port || 8125, config.address || undefined);
-  this.server = server;
+  server.on('listening', (e) => {
+    config.socket && config.socket_mod && fs.chmod(config.socket, config.socket_mod);
+  });
 
+  process.on('exit', (e) => {
+      config.socket && fs.unlinkSync(config.socket);
+  })
+
+  server.listen(config.socket || config.port || 8125, config.address || undefined);
+  this.server = server;
   return true;
 };

--- a/servers/tcp.js
+++ b/servers/tcp.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 function rinfo(tcpstream, data) {
     this.address = tcpstream.remoteAddress;
     this.port = tcpstream.remotePort;
-    this.family = tcpstream.address().family;
+    this.family = tcpstream.address() ? tcpstream.address().family : 'IPv4';
     this.size = data.length;
 }
 

--- a/servers/tcp.js
+++ b/servers/tcp.js
@@ -24,13 +24,13 @@ exports.start = function(config, callback) {
       });
   });
 
-  server.on('listening', (e) => {
+  server.on('listening', function() {
     config.socket && config.socket_mod && fs.chmod(config.socket, config.socket_mod);
   });
 
-  process.on('exit', (e) => {
+  process.on('exit', function() {
       config.socket && fs.unlinkSync(config.socket);
-  })
+  });
 
   server.listen(config.socket || config.port || 8125, config.address || undefined);
   this.server = server;

--- a/test/server_tests.js
+++ b/test/server_tests.js
@@ -1,5 +1,6 @@
 var dgram = require('dgram'),
-    net = require('net');
+    net = require('net'),
+    fs = require('fs');
 
 var config = {
     address: '127.0.0.1',
@@ -59,5 +60,24 @@ module.exports = {
         });
         client.end();
     });
+  },
+  unix_socket_data_received: function(test) {
+    test.expect(3);
+    var server = require('../servers/tcp');
+    config.socket = './statsd_tmp.socket';
+    var started = server.start(config, function (data, rinfo) {
+        test.equal(msg, data.toString());
+        test.equal(msg.length, rinfo.size);
+        fs.unlinkSync(config.socket);
+        config.socket = undefined;
+        test.done();
+    });
+
+    test.ok(started);
+
+    var client = net.connect(config.socket, function () {
+        client.write(msg);
+        client.end();
+    });
   }
-}
+};


### PR DESCRIPTION
* Add socket config option to specify path where socket will be stored.
* Add socket_mod config option to set correct permission on socket file.
* Remove socket on process exit.
* Update exampleConfig.js.