### PR TITLE
Make statsd work with newer version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
+  - '0.10'
+  - '0.12'
+  - '4'
+  - 'stable'
 script: ./run_tests.sh
 notifications:
   email: false

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,7 +8,7 @@ var Logger = function (config) {
     this.util = require('util');
   } else {
     if (this.backend == 'syslog') {
-      this.util = require('node-syslog');
+      this.util = require('modern-syslog');
       this.util.init(config.application || 'statsd', this.util.LOG_PID | this.util.LOG_ODELAY, this.util.LOG_LOCAL0);
     } else {
       throw "Logger: Should be 'stdout' or 'syslog'.";

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "temp": "0.4.x"
   },
   "optionalDependencies": {
-    "node-syslog":"1.2.0",
+    "modern-syslog":"1.1.2",
     "hashring":"3.2.0",
     "winser": "=0.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "generic-pool": "2.2.0"
   },
   "devDependencies": {
-    "nodeunit": "0.7.x",
+    "nodeunit": "0.9.x",
     "underscore": "1.4.x",
     "temp": "0.4.x"
   },


### PR DESCRIPTION
node-syslog doesn't work with newer node.js versions and it's website says it not supported, so changed this dependency to modern-syslog library.
https://github.com/schamane/node-syslog

nodeunit 0.7.x doesn't compatible with newer node.js versions, so an update was required.
https://github.com/caolan/nodeunit/issues/291