### PR TITLE
Allow the proxy to listen over TCP

### DIFF
--- a/exampleProxyConfig.js
+++ b/exampleProxyConfig.js
@@ -15,6 +15,12 @@ Optional Variables:
   checkInterval:    health status check interval [default: 10000]
   cacheSize:        size of the cache to store for hashring key lookups [default: 10000]
   forkCount:        number of child processes (cluster module), number or 'auto' for utilize all cpus [default:0]
+  server:           the server to load. The server must exist by name in the directory
+                    servers/. If not specified, the default udp server will be loaded.
+                    Note: This will still send to the backends via udp regardless of the
+                    server type for the proxy
+                    * example for tcp server:
+                    "./servers/tcp"
 
 */
 {
@@ -23,6 +29,7 @@ nodes: [
 {host: '127.0.0.1', port: 8129, adminport: 8130},
 {host: '127.0.0.1', port: 8131, adminport: 8132}
 ],
+server: './servers/udp',
 udp_version: 'udp4',
 host:  '0.0.0.0',
 port: 8125,

--- a/proxy.js
+++ b/proxy.js
@@ -62,7 +62,10 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
 
 
   // Setup the udp listener
-  var server = dgram.createSocket(udp_version, function (msg, rinfo) {
+  //
+  var server_config = config.server  || './servers/udp'
+  var servermod = require(server_config)
+  var server = servermod.start(config, function (msg, rinfo) {
     // Convert the raw packet to a string (defaults to UTF8 encoding)
     var packet_data = msg.toString();
     // If the packet contains a \n then it contains multiple metrics
@@ -107,9 +110,6 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
       client.send(msg, 0, msg.length, host_config[1], host_config[0]);
     }
   });
-
-  // Bind the listening udp server to the configured port and host
-  server.bind(config.port, config.host || undefined);
 
   // Set the interval for healthchecks
   setInterval(doHealthChecks, config.checkInterval || 10000);


### PR DESCRIPTION
I'd like to eventually allow the proxy to send to its backends over tcp, but I felt it was fine for that to be a separate commit, since the proxy currently does not respect server configuration of the backends as it is.