### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:onbuild
+FROM node:5-onbuild
 
 RUN \
   cp -v exampleConfig.js config.js && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:onbuild
+
+RUN \
+  cp -v exampleConfig.js config.js && \
+  sed -i 's/graphite.example.com/graphite/' config.js
+
+EXPOSE 8125/udp
+EXPOSE 8126
+
+ENTRYPOINT [ "node", "stats.js", "config.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+statsd:
+  build: .
+  links:
+  - carbon:graphite
+  ports:
+  - 8125:8125/udp
+  - 8126:8126
+
+graphite-web:
+  image: dockerana/graphite
+  links:
+  - carbon
+  ports:
+  - 8000:8000
+  volumes_from:
+  - carbon
+
+carbon:
+  image: dockerana/carbon
+  ports:
+  - 2003:2003
+  - 2004:2004
+  - 7002:7002
+  volumes:
+  - /opt/graphite


### PR DESCRIPTION
Add Dockerfile to enable image building.
By now, I use the official Node image, 'onbuild' tag. More info at https://hub.docker.com/_/node/

Later, I just simply copy the exampleConfig.js into config.js and replace the 'graphite.example.com' hostname by 'graphite' to enable Docker native networking, be it via linking or via aliasing external hosts/containers as 'graphite' and always connect to the 'graphite' host.

Build:
```
$ docker build -t statsd .
```

Run (assuming a previously running Graphite Docker conatiner named graphite):
```
$ docker run -d -it --name statsd --link graphite -p 8125:8125/udp -p 8126:8126 statsd
```

More optional improvements to come:
* Creating a dockerConfig.js file which reads all config parametes from environment vars (as I've done previously for movableink/doorman)
* Create an 'official' automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/