### PR TITLE
Updated graphite link to read the docs

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -56,4 +56,4 @@ queues and third-party services.
 - [statsd aggregation backend](https://github.com/wanelo/gossip_girl)
 - [zabbix-backend](https://github.com/parkerd/statsd-zabbix-backend)
 
-[graphite]: http://graphite.wikidot.com
+[graphite]: https://graphite.readthedocs.io/en/latest/


### PR DESCRIPTION
http://graphite.wikidot.com/ says it is out of date on the left hand side and links to the read the docs