### PR TITLE
replaced process.eventemitter with events eventemitter

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -30,7 +30,9 @@ var Configurator = function (file) {
   });
 };
 
-util.inherits(Configurator, process.EventEmitter);
+//util.inherits(Configurator, process.EventEmitter);
+var EventEmitter = require('events').EventEmitter;                                           
+util.inherits(Configurator, EventEmitter);   
 
 exports.Configurator = Configurator;
 


### PR DESCRIPTION
On debian 7, node 7.1.0 and npm 3.10.9 the line util.inherits(Configurator, process.EventEmitter) resulted in an error because this is deprecated. based on a stackoverflow link I replaced it with the following two lines

var EventEmitter = require('events').EventEmitter;                                           
util.inherits(Configurator, EventEmitter);  

Below some documentation information on my system and the error message and resource from where I took the solution.

--------------------------------------------------------------

root@localhost:~/statsd_git/statsd# npm -v
3.10.9

root@localhost:~/statsd_git/statsd# node -v
v7.1.0

--------------------------------------------------------------

root@localhost:~/statsd_git/statsd# node stats.js exampleConfig.js 
util.js:961
    throw new TypeError('The super constructor to "inherits" must not ' +
    ^

TypeError: The super constructor to "inherits" must not be null or undefined
    at Object.exports.inherits (util.js:961:11)
    at Object.<anonymous> (/root/statsd_git/statsd/lib/config.js:33:6)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/root/statsd_git/statsd/stats.js:4:14)

root@localhost:~/statsd_git/statsd# node stats.js local.js 
util.js:961
    throw new TypeError('The super constructor to "inherits" must not ' +
    ^

TypeError: The super constructor to "inherits" must not be null or undefined
    at Object.exports.inherits (util.js:961:11)
    at Object.<anonymous> (/root/statsd_git/statsd/lib/config.js:33:6)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/root/statsd_git/statsd/stats.js:4:14)


---------------------------- CODE ----------------------------------
//util.inherits(Configurator, process.EventEmitter);                                         
                                                                                             
var EventEmitter = require('events').EventEmitter;                                           
util.inherits(Configurator, EventEmitter);   

--------------------------------------------------------------
root@localhost:~/statsd_git/statsd# node stats.js local.js 
13 Nov 12:41:20 - [28821] reading config file: local.js
13 Nov 12:41:20 - DEBUG: Loading server: ./servers/udp
13 Nov 12:41:20 - server is up INFO
13 Nov 12:41:20 - DEBUG: Loading backend: ./backends/graphite

--------------------------------------------------------------

http://stackoverflow.com/questions/8898399/node-js-inheriting-from-eventemitter
https://nodejs.org/api/events.html