### PR TITLE
add support to negative number as value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 # WebStorm / IntelliJ IDEA project files
 .idea
 *.iml
+.DS_Store

--- a/docs/metric_types.md
+++ b/docs/metric_types.md
@@ -98,8 +98,11 @@ So if `gaugor` was `333`, those commands would set it to `333 - 10 + 4`, or
 
 Note:
 
-This implies you can't explicitly set a gauge to a negative number
-without first setting it to zero.
+If you want to set a gauge to a negative number, please follow this format.
+
+	gaugor:(-10)|g
+	
+In this case StatsD will take the negative number as the new value. 
 
 Sets
 ----

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,7 +39,7 @@ function is_valid_packet(fields) {
         case 's':
             return true;
         case 'g':
-            return isNumber(fields[0]);
+            return isNumber(fields[0].replace(/\(|\)/g,''));
         case 'ms':
             return isNumber(fields[0]) && Number(fields[0]) >= 0;
         default:

--- a/stats.js
+++ b/stats.js
@@ -270,7 +270,8 @@ config.configFile(process.argv[2], function (config) {
             if (gauges[key] && fields[0].match(/^[-+]/)) {
               gauges[key] += Number(fields[0] || 0);
             } else {
-              gauges[key] = Number(fields[0] || 0);
+              var maybe_negative_value = fields[0] || 0;
+              gauges[key] = Number(maybe_negative_value.replace(/\(|\)/g,''));
             }
           } else if (metric_type === "s") {
             if (! sets[key]) {

--- a/test/graphite_tests.js
+++ b/test/graphite_tests.js
@@ -328,6 +328,68 @@ module.exports = {
     });
   },
 
+  gauges_negative_are_valid: function(test) {
+    test.expect(2);
+    var tempme;
+    var testvalue = '(-70)';
+    var testresult = Number(testvalue.replace(/\(|\)/g,''));
+    var me = this;
+    this.acceptor.once('connection', function(c) {
+      statsd_send('a_test_value:' + testvalue + '|g', me.sock, '127.0.0.1', 8125, function() {
+        collect_for(me.acceptor, me.myflush*2, function(strings) {
+          test.ok(strings.length > 0, 'should receive some data');
+          var hashes = _.map(strings, function(x) {
+            var chunks = x.split(' ');
+            var data = {};
+            data[chunks[0]] = chunks[1];
+            return data;
+          });
+
+          var gaugevalue_test = function(post) {
+            var mykey = 'stats.gauges.a_test_value';
+            tempme = post[mykey];
+            return _.include(_.keys(post), mykey) && (post[mykey] == testresult);
+          };
+          test.ok(_.any(hashes, gaugevalue_test), 'stats.gauges.a_test_value should be ' + tempme);
+
+          test.done();
+        });
+      });
+    });
+  },
+
+  gauge_negatives_are_valid: function(test) {
+    test.expect(2);
+
+    var teststartvalue = 50;
+    var testdeltavalue = '(-3)';
+    var testresult = -3;
+    var me = this;
+    this.acceptor.once('connection', function(c) {
+      statsd_send('test_value:' + teststartvalue + '|g', me.sock, '127.0.0.1', 8125, function() {
+        statsd_send('test_value:' + testdeltavalue + '|g', me.sock, '127.0.0.1', 8125, function() {
+          collect_for(me.acceptor, me.myflush * 2, function(strings) {
+            test.ok(strings.length > 0, 'should receive some data');
+            var hashes = _.map(strings, function(x) {
+              var chunks = x.split(' ');
+              var data = {};
+              data[chunks[0]] = chunks[1];
+              return data;
+            });
+
+            var gaugevalue_test = function(post) {
+              var mykey = 'stats.gauges.test_value';
+              return _.include(_.keys(post), mykey) && (post[mykey] == testresult);
+            };
+            test.ok(_.any(hashes, gaugevalue_test), 'stats.gauges.test_value should be ' + testresult);
+
+            test.done();
+          });
+        });
+      });
+    });
+  },
+
   gauge_modifications_are_valid: function(test) {
     test.expect(2);
 


### PR DESCRIPTION
Set gauge to 0 before set it to negative number sometimes annoying. So i proposed this change to allow StatsD take "gauge:(-10)|g" to set value to -10 instead of changing previous value.