### PR TITLE
Refactor use of EventEmitter to work with Node versions 6 and above

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,36 +1,39 @@
 /*jshint node:true, laxcomma:true */
 
 var fs  = require('fs')
-  , util = require('util');
+  , util = require('util')
+  , EventEmitter = require('events').EventEmitter;
 
-var Configurator = function (file) {
+function Configurator (file) {
+  EventEmitter.call(this);
 
-  var self = this;
-  var config = {};
-  var oldConfig = {};
-
-  this.updateConfig = function () {
-    util.log('[' + process.pid + '] reading config file: ' + file);
-
-    fs.readFile(file, function (err, data) {
-      if (err) { throw err; }
-      old_config = self.config;
-
-      self.config = eval('config = ' + data);
-      self.emit('configChanged', self.config);
-    });
-  };
-
+  this.file = file;
+  this.config = {};
+  this.oldConfig = {};
   this.updateConfig();
 
+  var self = this;
   fs.watch(file, function (event, filename) {
     if (event == 'change' && self.config.automaticConfigReload != false) {
       self.updateConfig();
     }
   });
-};
+}
 
-util.inherits(Configurator, require('events').EventEmitter);
+Configurator.prototype = Object.create(EventEmitter.prototype);
+Configurator.constructor = Configurator;
+Configurator.prototype.updateConfig = function () {
+  util.log('[' + process.pid + '] reading config file: ' + this.file);
+
+  var self = this;
+  fs.readFile(this.file, function (err, data) {
+    if (err) { throw err; }
+    old_config = self.config;
+
+    self.config = eval('config = ' + data);
+    self.emit('configChanged', self.config);
+  });
+};
 
 exports.Configurator = Configurator;
 


### PR DESCRIPTION
Small change that will allow statsd to be run on Node version 6 and up.  All test pass in multiple version of Node v6 and in the latest LTS v8.9.1