### PR TITLE
Sanitize key when globalKeySanitize is true

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -163,11 +163,11 @@ var flush_stats = function graphite_flush(ts, metrics) {
   // Sanitize key for graphite if not done globally
   function sk(key) {
     if (globalKeySanitize) {
-      return key;
-    } else {
       return key.replace(/\s+/g, '_')
                 .replace(/\//g, '-')
                 .replace(/[^a-zA-Z_\-0-9\.]/g, '');
+    } else {
+      return key
     }
   };
 


### PR DESCRIPTION
The existing code prevents tagged metrics from being posted even though the keyNameSanitize key in the configuration file is set to true.

Made a minor modification to have the if statement match the configuration option.