### PR TITLE
Fixed (node:29694) [DEP0005] DeprecationWarning: Buffer() is deprecat…

### DIFF
--- a/backends/graphite.js
+++ b/backends/graphite.js
@@ -138,7 +138,7 @@ function Stats() {
     // The first four bytes of the graphite pickle format
     // contain the length of the rest of the payload.
     // We use Buffer because this is binary data.
-    var buf = new Buffer(4 + body.length);
+    var buf = Buffer.alloc(4 + body.length);
 
     buf.writeUInt32BE(body.length,0);
     buf.write(body,4);

--- a/backends/repeater.js
+++ b/backends/repeater.js
@@ -106,7 +106,7 @@ TCPRepeaterBackend.prototype.process = function(packet, rinfo) {
   }
 
   for(var i = 0; i < this.pools.length; i++) {
-    send(new Buffer(packet.toString() + "\n"), this.pools[i]);
+    send(Buffer.from(packet.toString() + "\n"), this.pools[i]);
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "statsd",
-  "version": "0.8.6",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/proxy.js
+++ b/proxy.js
@@ -121,7 +121,7 @@ configlib.configFile(process.argv[2], function (conf, oldConfig) {
           bits = current_metric.split(':');
           key = bits.shift();
           if (current_metric !== '') {
-            var new_msg = new Buffer(current_metric);
+            var new_msg = Buffer.from(current_metric);
             packet.emit('send', key, new_msg);
           }
         }

--- a/test/graphite_delete_counters_tests.js
+++ b/test/graphite_delete_counters_tests.js
@@ -35,7 +35,7 @@ var array_contents_are_equal = function(first,second){
 }
 
 var statsd_send = function(data,sock,host,port,cb){
-  send_data = new Buffer(data);
+  send_data = Buffer.from(data);
   sock.send(send_data,0,send_data.length,port,host,function(err,bytes){
     if (err) {
       throw err;

--- a/test/graphite_legacy_tests.js
+++ b/test/graphite_legacy_tests.js
@@ -28,7 +28,7 @@ var array_contents_are_equal = function(first,second){
 }
 
 var statsd_send = function(data,sock,host,port,cb){
-  send_data = new Buffer(data);
+  send_data = Buffer.from(data);
   sock.send(send_data,0,send_data.length,port,host,function(err,bytes){
     if (err) {
       throw err;

--- a/test/graphite_legacy_tests_statsprefix.js
+++ b/test/graphite_legacy_tests_statsprefix.js
@@ -28,7 +28,7 @@ var array_contents_are_equal = function(first,second){
 }
 
 var statsd_send = function(data,sock,host,port,cb){
-  send_data = new Buffer(data);
+  send_data = Buffer.from(data);
   sock.send(send_data,0,send_data.length,port,host,function(err,bytes){
     if (err) {
       throw err;

--- a/test/graphite_pickle_tests.js
+++ b/test/graphite_pickle_tests.js
@@ -23,7 +23,7 @@ var writeconfig = function(text,worker,cb,obj){
 };
 
 var statsd_send = function(data,sock,host,port,cb){
-  send_data = new Buffer(data);
+  send_data = Buffer.from(data);
   sock.send(send_data,0,send_data.length,port,host,function(err,bytes){
     if (err) {
       throw err;
@@ -36,7 +36,7 @@ var statsd_send = function(data,sock,host,port,cb){
 // this will let us capture all data chunks so we don't miss one
 var collect_for = function(server,timeout,cb){
   // We have binary data arriving over the wire. Avoid strings.
-  var received = new Buffer(0);
+  var received = Buffer.alloc(0);
   var in_flight = 0;
   var timed_out = false;
   var collector = function(req,res){

--- a/test/graphite_tests.js
+++ b/test/graphite_tests.js
@@ -28,7 +28,7 @@ var array_contents_are_equal = function(first,second){
 }
 
 var statsd_send = function(data,sock,host,port,cb){
-  send_data = new Buffer(data);
+  send_data = Buffer.from(data);
   sock.send(send_data,0,send_data.length,port,host,function(err,bytes){
     if (err) {
       throw err;

--- a/test/graphite_tests_filters.js
+++ b/test/graphite_tests_filters.js
@@ -22,7 +22,7 @@ var writeconfig = function(text, worker, cb, obj){
 }
 
 var statsd_send = function(data,sock,host,port,cb){
-  send_data = new Buffer(data);
+  send_data = Buffer.from(data);
   sock.send(send_data,0,send_data.length,port,host,function(err,bytes){
     if (err) {
       throw err;

--- a/test/graphite_tests_statsprefix.js
+++ b/test/graphite_tests_statsprefix.js
@@ -28,7 +28,7 @@ var array_contents_are_equal = function(first,second){
 }
 
 var statsd_send = function(data,sock,host,port,cb){
-  send_data = new Buffer(data);
+  send_data = Buffer.from(data);
   sock.send(send_data,0,send_data.length,port,host,function(err,bytes){
     if (err) {
       throw err;

--- a/test/graphite_tests_statssuffix.js
+++ b/test/graphite_tests_statssuffix.js
@@ -28,7 +28,7 @@ var array_contents_are_equal = function(first,second){
 }
 
 var statsd_send = function(data,sock,host,port,cb){
-  send_data = new Buffer(data);
+  send_data = Buffer.from(data);
   sock.send(send_data,0,send_data.length,port,host,function(err,bytes){
     if (err) {
       throw err;

--- a/test/repeater_tests.js
+++ b/test/repeater_tests.js
@@ -72,7 +72,7 @@ RepeaterServer.prototype.start = function(cb) {
 };
 
 RepeaterServer.prototype.send = function(stringval) {
-  this.emitter.emit('packet', new Buffer(stringval), {});
+  this.emitter.emit('packet', Buffer.from(stringval), {});
 };
 
 RepeaterServer.prototype.stop = function(cb) {

--- a/test/server_tests.js
+++ b/test/server_tests.js
@@ -19,7 +19,7 @@ module.exports = {
     });
     test.ok(started);
 
-    var buf = new Buffer(msg);
+    var buf = Buffer.from(msg);
     var sock = dgram.createSocket('udp4');
     sock.send(buf, 0, buf.length, config.port, config.address, function(err, bytes) {
           sock.close();


### PR DESCRIPTION
When running statsd on a node version >= 10 the following deprecation warning appears 

(node:29694) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)